### PR TITLE
geom_alt props

### DIFF
--- a/data/421/170/391/421170391.geojson
+++ b/data/421/170/391/421170391.geojson
@@ -521,6 +521,9 @@
     ],
     "wof:country":"ET",
     "wof:created":1459008851,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1e4ecab4babd4864f97b7cbc3ce8d424",
     "wof:hierarchy":[
         {
@@ -532,7 +535,7 @@
         }
     ],
     "wof:id":421170391,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1582362126,
     "wof:name":"Addis Ababa",
     "wof:parent_id":1108695109,
     "wof:placetype":"locality",

--- a/data/421/171/033/421171033.geojson
+++ b/data/421/171/033/421171033.geojson
@@ -98,6 +98,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459008879,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"924ded4e85b0f0e0c2687074ed8a4068",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":421171033,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1582362126,
     "wof:name":"Gambella Zone 3",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/421/182/273/421182273.geojson
+++ b/data/421/182/273/421182273.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009324,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"da9ec6d27486568e15776d78a53fbe17",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421182273,
-    "wof:lastmodified":1566593559,
+    "wof:lastmodified":1582362126,
     "wof:name":"Gurage",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/421/184/699/421184699.geojson
+++ b/data/421/184/699/421184699.geojson
@@ -111,6 +111,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009419,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"bdc01eadcaf7db660cf3d012afee8437",
     "wof:hierarchy":[
         {
@@ -121,7 +124,7 @@
         }
     ],
     "wof:id":421184699,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1582362126,
     "wof:name":"Shinile",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/188/217/421188217.geojson
+++ b/data/421/188/217/421188217.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009538,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"810d4053f853883de6a37fdef356e1c0",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421188217,
-    "wof:lastmodified":1566593555,
+    "wof:lastmodified":1582362126,
     "wof:name":"Gambela Zone 1",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/421/188/225/421188225.geojson
+++ b/data/421/188/225/421188225.geojson
@@ -114,6 +114,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009538,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"63f5cdf51995ea1ac8ea9fc9be320327",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":421188225,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1582362126,
     "wof:name":"Borena",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/421/188/343/421188343.geojson
+++ b/data/421/188/343/421188343.geojson
@@ -96,6 +96,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009542,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21958ad5a580097e9fe88fae014597d3",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":421188343,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1582362126,
     "wof:name":"Jijiga",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/190/257/421190257.geojson
+++ b/data/421/190/257/421190257.geojson
@@ -286,6 +286,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009652,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55af5b00c86b1ce9f1ad264d852e5e71",
     "wof:hierarchy":[
         {
@@ -296,7 +299,7 @@
         }
     ],
     "wof:id":421190257,
-    "wof:lastmodified":1566593557,
+    "wof:lastmodified":1582362126,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85671159,
     "wof:placetype":"county",

--- a/data/421/195/685/421195685.geojson
+++ b/data/421/195/685/421195685.geojson
@@ -348,6 +348,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459009856,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"25f640037ea85d715b3a725fe76097d3",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
         }
     ],
     "wof:id":421195685,
-    "wof:lastmodified":1566593551,
+    "wof:lastmodified":1582362126,
     "wof:name":"Harer",
     "wof:parent_id":1108695173,
     "wof:placetype":"locality",

--- a/data/421/200/119/421200119.geojson
+++ b/data/421/200/119/421200119.geojson
@@ -203,6 +203,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459010012,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"1f20d3b773afce26074c735dda06e7f5",
     "wof:hierarchy":[
         {
@@ -213,7 +216,7 @@
         }
     ],
     "wof:id":421200119,
-    "wof:lastmodified":1566593557,
+    "wof:lastmodified":1582362126,
     "wof:name":"Gode",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/200/427/421200427.geojson
+++ b/data/421/200/427/421200427.geojson
@@ -89,6 +89,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459010022,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7d2d83800ca394209dea8a46d4718b95",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":421200427,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1582362126,
     "wof:name":"Gambela Zone 2",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/421/204/107/421204107.geojson
+++ b/data/421/204/107/421204107.geojson
@@ -115,6 +115,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459010174,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57e1e19b2497c24b482ef7fa5d5cfbfc",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":421204107,
-    "wof:lastmodified":1566593553,
+    "wof:lastmodified":1582362126,
     "wof:name":"Gedeo",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/421/204/421/421204421.geojson
+++ b/data/421/204/421/421204421.geojson
@@ -110,6 +110,9 @@
     },
     "wof:country":"ET",
     "wof:created":1459010185,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d659ce468761f5fcd649528848d36e28",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":421204421,
-    "wof:lastmodified":1566593553,
+    "wof:lastmodified":1582362126,
     "wof:name":"Sidama",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/856/322/57/85632257.geojson
+++ b/data/856/322/57/85632257.geojson
@@ -1010,6 +1010,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
+        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1065,6 +1066,11 @@
     },
     "wof:country":"ET",
     "wof:country_alpha3":"ETH",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"0a5147bfef410b70b84d2caa7a138542",
     "wof:hierarchy":[
         {
@@ -1079,7 +1085,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592986,
+    "wof:lastmodified":1582362113,
     "wof:name":"Ethiopia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/57/85632257.geojson
+++ b/data/856/322/57/85632257.geojson
@@ -1010,7 +1010,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -1085,7 +1084,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362113,
+    "wof:lastmodified":1583243011,
     "wof:name":"Ethiopia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/711/21/85671121.geojson
+++ b/data/856/711/21/85671121.geojson
@@ -332,6 +332,9 @@
         "wk:page":"Amhara Region"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"cfb73d2a1adfd94dfd43d5e472301995",
     "wof:hierarchy":[
         {
@@ -347,7 +350,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592990,
+    "wof:lastmodified":1582362115,
     "wof:name":"Amhara",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/25/85671125.geojson
+++ b/data/856/711/25/85671125.geojson
@@ -314,6 +314,9 @@
         "wk:page":"Tigray Region"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7c87bfe9a71a775ea44ff9f79e7eb56d",
     "wof:hierarchy":[
         {
@@ -329,7 +332,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592992,
+    "wof:lastmodified":1582362116,
     "wof:name":"Tigray",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/29/85671129.geojson
+++ b/data/856/711/29/85671129.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Afar Region"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9550aca8a970b74d6d2f307dae2781c7",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592990,
+    "wof:lastmodified":1582362115,
     "wof:name":"Afar",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/33/85671133.geojson
+++ b/data/856/711/33/85671133.geojson
@@ -344,6 +344,9 @@
         "wd:id":"Q203193"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40801fb4cd322c5d76a1f155d4455968",
     "wof:hierarchy":[
         {
@@ -359,7 +362,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592989,
+    "wof:lastmodified":1582362115,
     "wof:name":"Southern Nations, Nationalities and Peoples",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/37/85671137.geojson
+++ b/data/856/711/37/85671137.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Gambela Region"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fa2f104029f0b77db86a95a6ab2097c7",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592990,
+    "wof:lastmodified":1582362115,
     "wof:name":"Gambella Peoples",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/41/85671141.geojson
+++ b/data/856/711/41/85671141.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q202107"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"38e94cdf74a49e9c03e74a98ac24c52e",
     "wof:hierarchy":[
         {
@@ -332,7 +335,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592991,
+    "wof:lastmodified":1582362115,
     "wof:name":"Oromiya",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/47/85671147.geojson
+++ b/data/856/711/47/85671147.geojson
@@ -321,6 +321,9 @@
         "wd:id":"Q207635"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"32083aba8d125554e1460fe8b9238d49",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592991,
+    "wof:lastmodified":1582362116,
     "wof:name":"Beneshangul Gumuz",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/49/85671149.geojson
+++ b/data/856/711/49/85671149.geojson
@@ -593,6 +593,9 @@
         421170391
     ],
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a56d100115d2c8887438662331ed250b",
     "wof:hierarchy":[
         {
@@ -608,7 +611,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592991,
+    "wof:lastmodified":1582362116,
     "wof:name":"Addis Ababa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/55/85671155.geojson
+++ b/data/856/711/55/85671155.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Somali Region"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3329cae3a46b184f3ae9d4e1908e8865",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592990,
+    "wof:lastmodified":1582362115,
     "wof:name":"Somali",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/59/85671159.geojson
+++ b/data/856/711/59/85671159.geojson
@@ -333,6 +333,9 @@
         "wd:id":"Q193486"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"55af5b00c86b1ce9f1ad264d852e5e71",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592989,
+    "wof:lastmodified":1582362115,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/63/85671163.geojson
+++ b/data/856/711/63/85671163.geojson
@@ -318,6 +318,9 @@
         "wk:page":"Harari Region"
     },
     "wof:country":"ET",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5b730a838fa4fb6a11e6eff9cfd8e4db",
     "wof:hierarchy":[
         {
@@ -333,7 +336,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1566592991,
+    "wof:lastmodified":1582362115,
     "wof:name":"Harari People",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/890/418/071/890418071.geojson
+++ b/data/890/418/071/890418071.geojson
@@ -105,6 +105,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469051233,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e1ce58df59d5aeefaae9260aa122db3c",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
         }
     ],
     "wof:id":890418071,
-    "wof:lastmodified":1566593566,
+    "wof:lastmodified":1582362126,
     "wof:name":"Jimma",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/890/421/359/890421359.geojson
+++ b/data/890/421/359/890421359.geojson
@@ -103,6 +103,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469051389,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a6b968088e906b3e6ce43fcc758e6791",
     "wof:hierarchy":[
         {
@@ -113,7 +116,7 @@
         }
     ],
     "wof:id":890421359,
-    "wof:lastmodified":1566593565,
+    "wof:lastmodified":1582362126,
     "wof:name":"Hadiya",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/890/435/323/890435323.geojson
+++ b/data/890/435/323/890435323.geojson
@@ -304,6 +304,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469052063,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"7ef3266ba03271ed16660793bada29dc",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
         }
     ],
     "wof:id":890435323,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1582362127,
     "wof:name":"Mekele",
     "wof:parent_id":1108695189,
     "wof:placetype":"locality",

--- a/data/890/441/637/890441637.geojson
+++ b/data/890/441/637/890441637.geojson
@@ -259,6 +259,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469052331,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"cd5e4b020dc1cc08d506d0acf0594e15",
     "wof:hierarchy":[
         {
@@ -270,7 +273,7 @@
         }
     ],
     "wof:id":890441637,
-    "wof:lastmodified":1566593562,
+    "wof:lastmodified":1582362126,
     "wof:name":"Debre Birhan",
     "wof:parent_id":1108695197,
     "wof:placetype":"locality",

--- a/data/890/442/043/890442043.geojson
+++ b/data/890/442/043/890442043.geojson
@@ -337,6 +337,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469052348,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ad540532db913217c864bb5a26e041cf",
     "wof:hierarchy":[
         {
@@ -348,7 +351,7 @@
         }
     ],
     "wof:id":890442043,
-    "wof:lastmodified":1566593566,
+    "wof:lastmodified":1582362127,
     "wof:name":"Gonder",
     "wof:parent_id":1108695193,
     "wof:placetype":"locality",

--- a/data/890/446/963/890446963.geojson
+++ b/data/890/446/963/890446963.geojson
@@ -104,6 +104,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469052574,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"21f1fb5150e7022e1b0d6e70d12d6c67",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
         }
     ],
     "wof:id":890446963,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1582362126,
     "wof:name":"Illubabor",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/890/450/041/890450041.geojson
+++ b/data/890/450/041/890450041.geojson
@@ -100,6 +100,9 @@
     },
     "wof:country":"ET",
     "wof:created":1469052721,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5743d182c4c23bbe5d411d110237db02",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890450041,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1582362127,
     "wof:name":"Bench Maji",
     "wof:parent_id":85671133,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.