### PR TITLE
Name updates

### DIFF
--- a/data/125/981/974/7/1259819747.geojson
+++ b/data/125/981/974/7/1259819747.geojson
@@ -81,7 +81,7 @@
         "Bundi"
     ],
     "name:ori_x_preferred":[
-        "\u0b2c\u0b41\u0b28\u0b4d\u0b26\u0b3f "
+        "\u0b2c\u0b41\u0b28\u0b4d\u0b26\u0b3f"
     ],
     "name:pol_x_preferred":[
         "Bundi"
@@ -111,8 +111,8 @@
     "wof:belongsto":[
         102191573,
         85632257,
-        85671141,
-        1108695233
+        1108695233,
+        85671141
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -130,7 +130,7 @@
         }
     ],
     "wof:id":1259819747,
-    "wof:lastmodified":1566593751,
+    "wof:lastmodified":1587163117,
     "wof:name":"Bundi",
     "wof:parent_id":1108695233,
     "wof:placetype":"locality",

--- a/data/421/170/391/421170391.geojson
+++ b/data/421/170/391/421170391.geojson
@@ -28,6 +28,9 @@
     "name:afr_x_preferred":[
         "Addis Abeba"
     ],
+    "name:aka_x_preferred":[
+        "Addis-Abeba"
+    ],
     "name:amh_x_preferred":[
         "\u12a0\u12f2\u1235 \u12a0\u1260\u1263"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:bak_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:bcl_x_preferred":[
+        "Addis Ababa"
     ],
     "name:bel_x_preferred":[
         "\u0410\u0434\u044b\u0441-\u0410\u0431\u0435\u0431\u0430"
@@ -130,6 +136,9 @@
     "name:fin_x_preferred":[
         "Addis Abeba"
     ],
+    "name:fit_x_preferred":[
+        "Addis Abeba"
+    ],
     "name:fra_x_preferred":[
         "Addis-Abeba"
     ],
@@ -180,6 +189,9 @@
     ],
     "name:hye_x_preferred":[
         "\u0531\u0564\u056b\u057d \u0531\u0562\u0565\u0562\u0561"
+    ],
+    "name:hyw_x_preferred":[
+        "\u0531\u057f\u056b\u057d \u0531\u057a\u0565\u057a\u0561"
     ],
     "name:ibo_x_preferred":[
         "Addis Ababa"
@@ -271,6 +283,9 @@
     "name:mar_x_preferred":[
         "\u0905\u0926\u093f\u0938 \u0905\u092c\u093e\u092c\u093e"
     ],
+    "name:mhr_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
     "name:mkd_x_preferred":[
         "\u0410\u0434\u0438\u0441 \u0410\u0431\u0435\u0431\u0430"
     ],
@@ -319,6 +334,9 @@
     "name:oci_x_preferred":[
         "Addis Abeba"
     ],
+    "name:olo_x_preferred":[
+        "Addis-Abeba"
+    ],
     "name:orm_x_preferred":[
         "Addis Abeba"
     ],
@@ -340,11 +358,17 @@
     "name:pol_x_preferred":[
         "Addis Abeba"
     ],
+    "name:por_br_x_preferred":[
+        "Adis Abeba"
+    ],
     "name:por_x_preferred":[
         "Adis Abeba"
     ],
     "name:que_x_preferred":[
         "Adis Ababa"
+    ],
+    "name:rmf_x_preferred":[
+        "Addis Abeba"
     ],
     "name:roh_x_preferred":[
         "Addis Abeba"
@@ -367,11 +391,35 @@
     "name:sin_x_preferred":[
         "\u0d85\u0da9\u0dd2\u0dc3\u0dca \u0d85\u0db6\u0dcf\u0db6\u0dcf"
     ],
+    "name:sjd_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:sje_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:sju_x_preferred":[
+        "Addis Abeba"
+    ],
     "name:slk_x_preferred":[
         "Addis Abeba"
     ],
     "name:slv_x_preferred":[
         "Adis Abeba"
+    ],
+    "name:sma_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:sme_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:smj_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:smn_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:sms_x_preferred":[
+        "Addis Abeba"
     ],
     "name:sna_x_preferred":[
         "Addis Ababa"
@@ -405,6 +453,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b85\u0b9f\u0bbf\u0bb8\u0bcd \u0b85\u0baa\u0bbe\u0baa\u0bbe"
+    ],
+    "name:tat_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
     ],
     "name:tel_x_preferred":[
         "\u0c05\u0c26\u0c4d\u0c26\u0c3f\u0c38\u0c4d \u0c05\u0c2c\u0c3e\u0c2c\u0c3e"
@@ -472,6 +523,12 @@
     "name:yue_x_preferred":[
         "\u963f\u8fea\u65af\u963f\u8c9d\u5df4"
     ],
+    "name:zho_hk_x_preferred":[
+        "\u4e9e\u7684\u65af\u4e9e\u8c9d\u5df4"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u963f\u8fea\u65af\u963f\u8c9d\u5df4"
+    ],
     "name:zho_x_preferred":[
         "\u4e9a\u7684\u65af\u4e9a\u8d1d\u5df4"
     ],
@@ -501,8 +558,8 @@
     "wof:belongsto":[
         102191573,
         85632257,
-        85671149,
-        1108695109
+        1108695109,
+        85671149
     ],
     "wof:breaches":[],
     "wof:capital_of":85632257,
@@ -535,7 +592,7 @@
         }
     ],
     "wof:id":421170391,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1587429040,
     "wof:name":"Addis Ababa",
     "wof:parent_id":1108695109,
     "wof:placetype":"locality",

--- a/data/421/197/339/421197339.geojson
+++ b/data/421/197/339/421197339.geojson
@@ -135,7 +135,7 @@
         "\u0e14\u0e34\u0e25\u0e32\u0e23\u0e4c"
     ],
     "name:tha_x_variant":[
-        "\u0e14\u0e34\u0e25\u0e32\u0e23\u0e4c "
+        "\u0e14\u0e34\u0e25\u0e32\u0e23\u0e4c"
     ],
     "name:tur_x_preferred":[
         "Dile"
@@ -147,7 +147,7 @@
         "\u062f\u0644\u0627 \u060c \u0627\u06cc\u062a\u06be\u0648\u067e\u06cc\u0627"
     ],
     "name:urd_x_variant":[
-        "\u062f\u0644\u0627 "
+        "\u062f\u0644\u0627"
     ],
     "name:vie_x_preferred":[
         "Dila"
@@ -268,8 +268,8 @@
     "wof:belongsto":[
         102191573,
         85632257,
-        85671133,
-        421204107
+        421204107,
+        85671133
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -292,7 +292,7 @@
         }
     ],
     "wof:id":421197339,
-    "wof:lastmodified":1566593557,
+    "wof:lastmodified":1587163137,
     "wof:name":"Dila",
     "wof:parent_id":421204107,
     "wof:placetype":"locality",

--- a/data/856/322/57/85632257.geojson
+++ b/data/856/322/57/85632257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":92.836084,
-    "geom:area_square_m":1133677223277.224121,
+    "geom:area_square_m":1133677221687.785889,
     "geom:bbox":"32.997734,3.404137,48.001056,14.894214",
     "geom:latitude":8.633117,
     "geom:longitude":39.632616,
@@ -69,6 +69,9 @@
     "name:arg_x_preferred":[
         "Etiopia"
     ],
+    "name:ary_x_preferred":[
+        "\u0625\u062a\u064a\u0648\u067e\u064a\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u062b\u064a\u0648\u0628\u064a\u0627"
     ],
@@ -95,6 +98,9 @@
     ],
     "name:bam_x_variant":[
         "Etiopi"
+    ],
+    "name:ban_x_preferred":[
+        "\u00c9thiopia"
     ],
     "name:bar_x_preferred":[
         "Ethiopien"
@@ -177,14 +183,26 @@
     "name:cor_x_preferred":[
         "Ethiopi"
     ],
+    "name:cos_x_preferred":[
+        "Ettiopia"
+    ],
     "name:crh_x_preferred":[
         "Abe\u015fistan"
+    ],
+    "name:csb_x_preferred":[
+        "Etiopi\u00f4"
     ],
     "name:cym_x_preferred":[
         "Ethiopia"
     ],
     "name:dan_x_preferred":[
         "Etiopien"
+    ],
+    "name:deu_at_x_preferred":[
+        "\u00c4thiopien"
+    ],
+    "name:deu_ch_x_preferred":[
+        "\u00c4thiopien"
     ],
     "name:deu_x_colloquial":[
         "Aethiopien",
@@ -215,6 +233,12 @@
     ],
     "name:ell_x_preferred":[
         "\u0391\u03b9\u03b8\u03b9\u03bf\u03c0\u03af\u03b1"
+    ],
+    "name:eng_ca_x_preferred":[
+        "Ethiopia"
+    ],
+    "name:eng_gb_x_preferred":[
+        "Ethiopia"
     ],
     "name:eng_x_preferred":[
         "Ethiopia"
@@ -283,6 +307,9 @@
     ],
     "name:gan_x_preferred":[
         "\u57c3\u585e\u4fc4\u6bd4\u4e9e"
+    ],
+    "name:gcr_x_preferred":[
+        "L\u00e9tchopi"
     ],
     "name:gla_x_preferred":[
         "An Aeti\u00f2p"
@@ -567,6 +594,9 @@
     "name:mon_x_preferred":[
         "\u042d\u0442\u0438\u043e\u043f"
     ],
+    "name:mri_x_preferred":[
+        "Etiopia"
+    ],
     "name:mrj_x_preferred":[
         "\u042d\u0444\u0438\u043e\u043f\u0438"
     ],
@@ -675,6 +705,9 @@
     "name:pol_x_preferred":[
         "Etiopia"
     ],
+    "name:por_br_x_preferred":[
+        "Eti\u00f3pia"
+    ],
     "name:por_x_preferred":[
         "Eti\u00f3pia"
     ],
@@ -777,6 +810,12 @@
     "name:srn_x_preferred":[
         "Ethiopikondre"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0415\u0442\u0438\u043e\u043f\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Etiopija"
+    ],
     "name:srp_x_preferred":[
         "\u0415\u0442\u0438\u043e\u043f\u0438\u0458\u0430"
     ],
@@ -800,6 +839,9 @@
     ],
     "name:szl_x_preferred":[
         "Etjopijo"
+    ],
+    "name:szy_x_preferred":[
+        "Ethiopia"
     ],
     "name:tah_x_preferred":[
         "Etiopi"
@@ -919,6 +961,9 @@
     ],
     "name:zho_min_nan_x_preferred":[
         "Ityop'iya"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u8863\u7d22\u6bd4\u4e9e"
     ],
     "name:zho_x_preferred":[
         "\u57c3\u585e\u4fc4\u6bd4\u4e9a"
@@ -1085,7 +1130,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1583797334,
+    "wof:lastmodified":1587429039,
     "wof:name":"Ethiopia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.