### PR TITLE
Flag coterminous places

### DIFF
--- a/data/110/869/517/3/1108695173.geojson
+++ b/data/110/869/517/3/1108695173.geojson
@@ -62,6 +62,9 @@
     "wof:concordances":{
         "hasc:id":"ET.HA.HA"
     },
+    "wof:coterminous":[
+        85671163
+    ],
     "wof:country":"ET",
     "wof:created":1474493498,
     "wof:geomhash":"5b730a838fa4fb6a11e6eff9cfd8e4db",
@@ -74,7 +77,7 @@
         }
     ],
     "wof:id":1108695173,
-    "wof:lastmodified":1566593387,
+    "wof:lastmodified":1607993758,
     "wof:name":"Harar/Hundene",
     "wof:parent_id":85671163,
     "wof:placetype":"county",

--- a/data/421/190/257/421190257.geojson
+++ b/data/421/190/257/421190257.geojson
@@ -284,6 +284,9 @@
         "wd:id":"Q193486",
         "wk:page":"Dire Dawa"
     },
+    "wof:coterminous":[
+        85671159
+    ],
     "wof:country":"ET",
     "wof:created":1459009652,
     "wof:geom_alt":[
@@ -299,7 +302,7 @@
         }
     ],
     "wof:id":421190257,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1607993768,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85671159,
     "wof:placetype":"county",

--- a/data/856/711/59/85671159.geojson
+++ b/data/856/711/59/85671159.geojson
@@ -332,6 +332,9 @@
         "unlc:id":"ET-DD",
         "wd:id":"Q193486"
     },
+    "wof:coterminous":[
+        421190257
+    ],
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
@@ -351,7 +354,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1607993768,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/63/85671163.geojson
+++ b/data/856/711/63/85671163.geojson
@@ -317,6 +317,9 @@
         "wd:id":"Q1033855",
         "wk:page":"Harari Region"
     },
+    "wof:coterminous":[
+        1108695173
+    ],
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
@@ -336,7 +339,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1607993758,
     "wof:name":"Harari People",
     "wof:parent_id":85632257,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of whosonfirst-data/whosonfirst-data#1906.

This PR attempts flag any locality, localadmin, county, macrocounty, or region record as coterminous with any parent records that are similar in size and have similar names.