### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/110/869/512/5/1108695125.geojson
+++ b/data/110/869/512/5/1108695125.geojson
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:amh_x_preferred":[
+        "\u12a0\u1308\u12cd \u12a0\u12ca \u12de\u1295"
+    ],
     "name:ceb_x_preferred":[
         "Awi"
     ],
@@ -43,11 +46,17 @@
         "Awi/Agew",
         "Agew Awi Zone"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u06af\u0627\u0648"
+    ],
     "name:fra_x_preferred":[
         "Agew Awi"
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05d2\u05d0\u05d5 \u05d0\u05d5\u05d9"
+    ],
+    "name:ita_x_preferred":[
+        "Awi"
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30b8\u30e5\u30fb\u30a2\u30a6\u30a3\u770c"
@@ -60,6 +69,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u53e4\u963f\u7dad\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Agew Awi Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -97,7 +109,7 @@
         }
     ],
     "wof:id":1108695125,
-    "wof:lastmodified":1566593397,
+    "wof:lastmodified":1690879613,
     "wof:name":"Agew Awi",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/513/1/1108695131.geojson
+++ b/data/110/869/513/1/1108695131.geojson
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:bel_x_preferred":[
+        "\u0437\u043e\u043d\u0430 \u0410\u0440\u0441\u0456"
+    ],
     "name:bul_x_preferred":[
         "\u0410\u0440\u0441\u0438"
     ],
@@ -55,6 +58,12 @@
     "name:fra_x_preferred":[
         "Arsi"
     ],
+    "name:hye_x_preferred":[
+        "\u0531\u0580\u057d\u056b\u056b \u0533\u0578\u057f\u056b"
+    ],
+    "name:ita_x_preferred":[
+        "Arussi"
+    ],
     "name:jpn_x_preferred":[
         "\u30a2\u30eb\u30b7\u5730\u57df"
     ],
@@ -73,8 +82,14 @@
     "name:swe_x_preferred":[
         "Arsi Zone"
     ],
+    "name:swe_x_variant":[
+        "Arsi"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u723e\u897f\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Arsi Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -112,7 +127,7 @@
         }
     ],
     "wof:id":1108695131,
-    "wof:lastmodified":1566593394,
+    "wof:lastmodified":1690879610,
     "wof:name":"Arsi",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/513/9/1108695139.geojson
+++ b/data/110/869/513/9/1108695139.geojson
@@ -45,6 +45,9 @@
     "name:eng_x_variant":[
         "Basketo"
     ],
+    "name:eus_x_preferred":[
+        "Basketoaren Woreda Berezia"
+    ],
     "name:fra_x_preferred":[
         "Basketo"
     ],
@@ -53,6 +56,9 @@
     ],
     "name:swe_x_preferred":[
         "Basketo"
+    ],
+    "name:zul_x_preferred":[
+        "Basketo special woreda"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -77,7 +83,7 @@
         }
     ],
     "wof:id":1108695139,
-    "wof:lastmodified":1566593393,
+    "wof:lastmodified":1690879610,
     "wof:name":"Basketo SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/514/5/1108695145.geojson
+++ b/data/110/869/514/5/1108695145.geojson
@@ -55,6 +55,9 @@
     "name:heb_x_preferred":[
         "\u05d4\u05de\u05d7\u05d5\u05d6 \u05d4\u05de\u05e8\u05db\u05d6\u05d9"
     ],
+    "name:ita_x_preferred":[
+        "Mehakelegnaw"
+    ],
     "name:jpn_x_preferred":[
         "\u30e1\u30e9\u30b1\u30ec\u30f3\u30ce\u30fc\u770c"
     ],
@@ -63,6 +66,12 @@
     ],
     "name:swe_x_preferred":[
         "Central Tigray Zone"
+    ],
+    "name:swe_x_variant":[
+        "Mehakelegnaw"
+    ],
+    "name:zul_x_preferred":[
+        "Maekelay Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -100,7 +109,7 @@
         }
     ],
     "wof:id":1108695145,
-    "wof:lastmodified":1566593393,
+    "wof:lastmodified":1690879610,
     "wof:name":"C. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/514/9/1108695149.geojson
+++ b/data/110/869/514/9/1108695149.geojson
@@ -45,6 +45,9 @@
     "name:nld_x_preferred":[
         "Degehabur"
     ],
+    "name:zul_x_preferred":[
+        "Degehabur"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1108695149,
-    "wof:lastmodified":1566593393,
+    "wof:lastmodified":1690879609,
     "wof:name":"Degehabur",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/515/7/1108695157.geojson
+++ b/data/110/869/515/7/1108695157.geojson
@@ -47,17 +47,32 @@
     "name:fra_x_preferred":[
         "Misraq Shewa"
     ],
+    "name:ita_x_preferred":[
+        "Scioa orientale"
+    ],
     "name:jpn_x_preferred":[
         "\u6771\u30b7\u30a7\u30ef\u770c"
     ],
     "name:orm_x_preferred":[
         "Baha Shawaa"
     ],
+    "name:pol_x_preferred":[
+        "Strefa East Sheva"
+    ],
+    "name:rus_x_preferred":[
+        "\u0412\u043e\u0441\u0442\u043e\u0447\u043d\u0430\u044f \u0428\u0435\u0432\u0430"
+    ],
     "name:swe_x_preferred":[
         "East Shewa Zone"
     ],
+    "name:swe_x_variant":[
+        "Misraq Shewa"
+    ],
     "name:zho_x_preferred":[
         "\u6771\u65bd\u74e6\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "East Shewa Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -95,7 +110,7 @@
         }
     ],
     "wof:id":1108695157,
-    "wof:lastmodified":1566593397,
+    "wof:lastmodified":1690879613,
     "wof:name":"E. Shewa",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/516/1/1108695161.geojson
+++ b/data/110/869/516/1/1108695161.geojson
@@ -42,9 +42,13 @@
     "name:eng_x_variant":[
         "Eastern",
         "Misraqawi",
-        "Misraqawi Zone"
+        "Misraqawi Zone",
+        "Eastern Zone"
     ],
     "name:fra_x_preferred":[
+        "Misraqawi"
+    ],
+    "name:ita_x_preferred":[
         "Misraqawi"
     ],
     "name:jpn_x_preferred":[
@@ -55,6 +59,12 @@
     ],
     "name:swe_x_preferred":[
         "Eastern Tigray Zone"
+    ],
+    "name:swe_x_variant":[
+        "Misraqawi"
+    ],
+    "name:zul_x_preferred":[
+        "Misraqawi Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -92,7 +102,7 @@
         }
     ],
     "wof:id":1108695161,
-    "wof:lastmodified":1566593392,
+    "wof:lastmodified":1690879609,
     "wof:name":"E. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/516/9/1108695169.geojson
+++ b/data/110/869/516/9/1108695169.geojson
@@ -48,6 +48,9 @@
     "name:spa_x_preferred":[
         "Godere"
     ],
+    "name:zul_x_preferred":[
+        "Godere"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":1108695169,
-    "wof:lastmodified":1566593391,
+    "wof:lastmodified":1690879609,
     "wof:name":"Godere",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/110/869/517/9/1108695179.geojson
+++ b/data/110/869/517/9/1108695179.geojson
@@ -45,6 +45,9 @@
     "name:fra_x_preferred":[
         "Kamashi"
     ],
+    "name:zul_x_preferred":[
+        "Kamashi"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":1108695179,
-    "wof:lastmodified":1566593387,
+    "wof:lastmodified":1690879607,
     "wof:name":"Kamashi",
     "wof:parent_id":85671147,
     "wof:placetype":"county",

--- a/data/110/869/518/7/1108695187.geojson
+++ b/data/110/869/518/7/1108695187.geojson
@@ -48,6 +48,9 @@
     "name:orm_x_preferred":[
         "Liiban"
     ],
+    "name:zul_x_preferred":[
+        "Liben"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "src:population":"statoids",
@@ -84,7 +87,7 @@
         }
     ],
     "wof:id":1108695187,
-    "wof:lastmodified":1566593389,
+    "wof:lastmodified":1690879608,
     "wof:name":"Liben",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/518/9/1108695189.geojson
+++ b/data/110/869/518/9/1108695189.geojson
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cym_x_preferred":[
+        "Parth Debubawi"
+    ],
     "name:eng_x_preferred":[
         "Debubawi Zone"
     ],
@@ -40,17 +43,29 @@
         "Southern",
         "Debubawi"
     ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u0633\u062a\u0627\u0646 \u062f\u0628\u0628\u0627\u0648\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Debubawi"
     ],
     "name:hrv_x_preferred":[
         "Zona Debubaji"
     ],
+    "name:ita_x_preferred":[
+        "Debubawi"
+    ],
     "name:jpn_x_preferred":[
         "\u30c7\u30d6\u30d0\u30a6\u30a3\u770c"
     ],
     "name:swe_x_preferred":[
         "Southern Tigray Zone"
+    ],
+    "name:swe_x_variant":[
+        "Debubawi"
+    ],
+    "name:zul_x_preferred":[
+        "Debubawi Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -76,7 +91,7 @@
         }
     ],
     "wof:id":1108695189,
-    "wof:lastmodified":1566593389,
+    "wof:lastmodified":1690879608,
     "wof:name":"Mekele",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/519/1/1108695191.geojson
+++ b/data/110/869/519/1/1108695191.geojson
@@ -54,11 +54,17 @@
     "name:heb_x_preferred":[
         "\u05de\u05ea\u05e7\u05dc"
     ],
+    "name:ita_x_preferred":[
+        "Metekel"
+    ],
     "name:jpn_x_preferred":[
         "\u30e1\u30c6\u30b1\u30eb\u770c"
     ],
     "name:swe_x_preferred":[
         "Metekel"
+    ],
+    "name:zul_x_preferred":[
+        "Metekel Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -96,7 +102,7 @@
         }
     ],
     "wof:id":1108695191,
-    "wof:lastmodified":1566593389,
+    "wof:lastmodified":1690879607,
     "wof:name":"Metekel",
     "wof:parent_id":85671147,
     "wof:placetype":"county",

--- a/data/110/869/520/3/1108695203.geojson
+++ b/data/110/869/520/3/1108695203.geojson
@@ -45,11 +45,17 @@
     "name:eng_x_variant":[
         "Oromia Zone"
     ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0627\u0648\u0631\u0648\u0645\u06cc\u0627"
+    ],
     "name:fra_x_preferred":[
         "Oromia"
     ],
     "name:heb_x_preferred":[
         "\u05d0\u05d5\u05e8\u05d5\u05de\u05d9\u05d4"
+    ],
+    "name:ita_x_preferred":[
+        "Oromia"
     ],
     "name:jpn_x_preferred":[
         "\u30aa\u30ed\u30df\u30a2\u770c"
@@ -60,8 +66,14 @@
     "name:swe_x_preferred":[
         "Oromia Zone"
     ],
+    "name:swe_x_variant":[
+        "Oromia"
+    ],
     "name:zho_x_preferred":[
         "\u5967\u7f85\u7c73\u4e9e\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Oromia Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -99,7 +111,7 @@
         }
     ],
     "wof:id":1108695203,
-    "wof:lastmodified":1566593391,
+    "wof:lastmodified":1690879608,
     "wof:name":"Oromiya",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/520/5/1108695205.geojson
+++ b/data/110/869/520/5/1108695205.geojson
@@ -49,6 +49,9 @@
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d2\u05d5\u05e0\u05d3\u05e8"
     ],
+    "name:ita_x_preferred":[
+        "Gondar meridionale"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u30b4\u30f3\u30c0\u30fc\u30eb\u770c"
     ],
@@ -58,8 +61,14 @@
     "name:swe_x_preferred":[
         "South Gondar Zone"
     ],
+    "name:swe_x_variant":[
+        "Debub Gondar"
+    ],
     "name:zho_x_preferred":[
         "\u5357\u8ca2\u5fb7\u723e\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "South Gondar Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":1108695205,
-    "wof:lastmodified":1566593391,
+    "wof:lastmodified":1690879609,
     "wof:name":"S. Gonder",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/520/7/1108695207.geojson
+++ b/data/110/869/520/7/1108695207.geojson
@@ -36,6 +36,9 @@
     "name:ceb_x_preferred":[
         "Southern Tigray Zone"
     ],
+    "name:cym_x_preferred":[
+        "Parth Debubawi"
+    ],
     "name:eng_x_preferred":[
         "Debubawi Zone"
     ],
@@ -43,17 +46,29 @@
         "Southern",
         "Debubawi"
     ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u0633\u062a\u0627\u0646 \u062f\u0628\u0628\u0627\u0648\u06cc"
+    ],
     "name:fra_x_preferred":[
         "Debubawi"
     ],
     "name:hrv_x_preferred":[
         "Zona Debubaji"
     ],
+    "name:ita_x_preferred":[
+        "Debubawi"
+    ],
     "name:jpn_x_preferred":[
         "\u30c7\u30d6\u30d0\u30a6\u30a3\u770c"
     ],
     "name:swe_x_preferred":[
         "Southern Tigray Zone"
+    ],
+    "name:swe_x_variant":[
+        "Debubawi"
+    ],
+    "name:zul_x_preferred":[
+        "Debubawi Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -79,7 +94,7 @@
         }
     ],
     "wof:id":1108695207,
-    "wof:lastmodified":1566593390,
+    "wof:lastmodified":1690879608,
     "wof:name":"S. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/520/9/1108695209.geojson
+++ b/data/110/869/520/9/1108695209.geojson
@@ -53,6 +53,9 @@
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d5\u05d5\u05dc\u05d5"
     ],
+    "name:ita_x_preferred":[
+        "Wello meridionale"
+    ],
     "name:jpn_x_preferred":[
         "\u5357\u30a6\u30a9\u30ed\u770c"
     ],
@@ -62,8 +65,17 @@
     "name:swe_x_preferred":[
         "South Wollo Zone"
     ],
+    "name:swe_x_variant":[
+        "Debub Wollo"
+    ],
+    "name:ukr_x_preferred":[
+        "\u041f\u0456\u0432\u0434\u0435\u043d\u043d\u0435 \u0412\u043e\u043b\u043b\u043e"
+    ],
     "name:zho_x_preferred":[
         "\u5357\u6c83\u6d1b\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "South Wollo Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -101,7 +113,7 @@
         }
     ],
     "wof:id":1108695209,
-    "wof:lastmodified":1566593390,
+    "wof:lastmodified":1690879608,
     "wof:name":"S. Wello",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/521/9/1108695219.geojson
+++ b/data/110/869/521/9/1108695219.geojson
@@ -33,8 +33,14 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:amh_x_preferred":[
+        "\u12f0\u1261\u1265 \u12a6\u121e"
+    ],
     "name:ceb_x_preferred":[
         "South Omo"
+    ],
+    "name:deu_x_preferred":[
+        "Debub Omo"
     ],
     "name:eng_x_preferred":[
         "Debub Omo"
@@ -46,6 +52,9 @@
     "name:fra_x_preferred":[
         "Debub Omo"
     ],
+    "name:ita_x_preferred":[
+        "Omo meridionale"
+    ],
     "name:jpn_x_preferred":[
         "\u30c7\u30d6\u30d6\u30fb\u30aa\u30e2\u770c"
     ],
@@ -55,8 +64,14 @@
     "name:swe_x_preferred":[
         "South Omo"
     ],
+    "name:swe_x_variant":[
+        "Debub Omo"
+    ],
     "name:zho_x_preferred":[
         "\u5357\u5967\u83ab\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "South Omo Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -94,7 +109,7 @@
         }
     ],
     "wof:id":1108695219,
-    "wof:lastmodified":1566593388,
+    "wof:lastmodified":1690879607,
     "wof:name":"South Omo",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/522/5/1108695225.geojson
+++ b/data/110/869/522/5/1108695225.geojson
@@ -49,8 +49,14 @@
     "name:heb_x_preferred":[
         "\u05d5\u05d2 \u05d4\u05de\u05e8\u05d4"
     ],
+    "name:ita_x_preferred":[
+        "Wag Hemra"
+    ],
     "name:jpn_x_preferred":[
         "\u30ef\u30b0\u30fb\u30d8\u30e0\u30e9\u770c"
+    ],
+    "name:pol_x_preferred":[
+        "Strefa Wag Himra"
     ],
     "name:rus_x_preferred":[
         "\u0412\u0430\u0433-\u0425\u0435\u043c\u0440\u0430"
@@ -58,8 +64,14 @@
     "name:swe_x_preferred":[
         "Wag Hemra Zone"
     ],
+    "name:swe_x_variant":[
+        "Wag Hemra"
+    ],
     "name:zho_x_preferred":[
         "\u74e6\u683c\u54c8\u59c6\u62c9\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Wag Hemra Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -97,7 +109,7 @@
         }
     ],
     "wof:id":1108695225,
-    "wof:lastmodified":1566593395,
+    "wof:lastmodified":1690879611,
     "wof:name":"W. Hamra",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/522/7/1108695227.geojson
+++ b/data/110/869/522/7/1108695227.geojson
@@ -46,14 +46,23 @@
     "name:fra_x_preferred":[
         "Mirab Hararghe"
     ],
+    "name:ita_x_preferred":[
+        "Hararge occidentale"
+    ],
     "name:orm_x_preferred":[
         "Dhiha Hararghe"
     ],
     "name:swe_x_preferred":[
         "West Harerghe Zone"
     ],
+    "name:swe_x_variant":[
+        "Mirab Hararghe"
+    ],
     "name:zho_x_preferred":[
         "\u897f\u54c8\u52d2\u723e\u84cb\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "West Hararghe Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":1108695227,
-    "wof:lastmodified":1566593395,
+    "wof:lastmodified":1690879611,
     "wof:name":"W. Haraerge",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/522/9/1108695229.geojson
+++ b/data/110/869/522/9/1108695229.geojson
@@ -50,10 +50,19 @@
     "name:heb_x_preferred":[
         "\u05d4\u05de\u05d7\u05d5\u05d6 \u05d4\u05de\u05e2\u05e8\u05d1\u05d9"
     ],
+    "name:ita_x_preferred":[
+        "Mi'irabawi"
+    ],
     "name:jpn_x_preferred":[
         "\u30df\u30a4\u30e9\u30d0\u30a6\u30a3\u770c"
     ],
     "name:swe_x_preferred":[
+        "Mi'irabawi Zone"
+    ],
+    "name:swe_x_variant":[
+        "Mi'irabawi"
+    ],
+    "name:zul_x_preferred":[
         "Mi'irabawi Zone"
     ],
     "src:geom":"meso",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":1108695229,
-    "wof:lastmodified":1566593394,
+    "wof:lastmodified":1690879611,
     "wof:name":"W. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/523/3/1108695233.geojson
+++ b/data/110/869/523/3/1108695233.geojson
@@ -47,17 +47,29 @@
     "name:fra_x_preferred":[
         "Mirab Welega"
     ],
+    "name:ita_x_preferred":[
+        "Uollegg\u00e0 occidentale"
+    ],
     "name:jpn_x_preferred":[
         "\u897f\u30a6\u30a7\u30ec\u30ac\u770c"
     ],
     "name:orm_x_preferred":[
         "Wallagga Dhihaa"
     ],
+    "name:pol_x_preferred":[
+        "Strefa Zachodnia Welega"
+    ],
     "name:swe_x_preferred":[
         "West Wellega Zone"
     ],
+    "name:swe_x_variant":[
+        "Mirab Welega"
+    ],
     "name:zho_x_preferred":[
         "\u897f\u6c83\u840a\u52a0\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "West Welega Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -95,7 +107,7 @@
         }
     ],
     "wof:id":1108695233,
-    "wof:lastmodified":1566593395,
+    "wof:lastmodified":1690879612,
     "wof:name":"W. Wellega",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/523/9/1108695239.geojson
+++ b/data/110/869/523/9/1108695239.geojson
@@ -41,10 +41,14 @@
     ],
     "name:eng_x_variant":[
         "West Shewa",
-        "Mirab Shewa Zone"
+        "Mirab Shewa Zone",
+        "West Shewa Zone"
     ],
     "name:fra_x_preferred":[
         "Mirab Shewa"
+    ],
+    "name:ita_x_preferred":[
+        "Scioa occidentale"
     ],
     "name:jpn_x_preferred":[
         "\u897f\u30b7\u30a7\u30ef\u770c"
@@ -55,8 +59,14 @@
     "name:swe_x_preferred":[
         "West Shewa Zone"
     ],
+    "name:swe_x_variant":[
+        "Mirab Shewa"
+    ],
     "name:zho_x_preferred":[
         "\u897f\u65bd\u74e6\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "West Shewa Zone"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -94,7 +104,7 @@
         }
     ],
     "wof:id":1108695239,
-    "wof:lastmodified":1566593395,
+    "wof:lastmodified":1690879611,
     "wof:name":"West Shewa",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/524/1/1108695241.geojson
+++ b/data/110/869/524/1/1108695241.geojson
@@ -51,6 +51,12 @@
     "name:swe_x_preferred":[
         "Yem Special Woreda"
     ],
+    "name:swe_x_variant":[
+        "Yem"
+    ],
+    "name:zul_x_preferred":[
+        "Yem special woreda"
+    ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
     "wof:belongsto":[
@@ -74,7 +80,7 @@
         }
     ],
     "wof:id":1108695241,
-    "wof:lastmodified":1566593396,
+    "wof:lastmodified":1690879612,
     "wof:name":"Yem SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/524/3/1108695243.geojson
+++ b/data/110/869/524/3/1108695243.geojson
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cat_x_preferred":[
+        "Awsi Rasu"
+    ],
     "name:eng_x_preferred":[
         "Afar Zone 1"
     ],
@@ -47,17 +50,32 @@
     "name:fra_x_preferred":[
         "Zone 1"
     ],
+    "name:fra_x_variant":[
+        "Awsi Resu"
+    ],
+    "name:hau_x_preferred":[
+        "Awsi Rasu"
+    ],
     "name:hrv_x_preferred":[
         "Upravna zona 1"
     ],
+    "name:ita_x_preferred":[
+        "Awsi"
+    ],
     "name:jpn_x_preferred":[
         "\u7b2c1\u30a2\u30d5\u30a1\u30fc\u30eb\u770c"
+    ],
+    "name:nld_x_preferred":[
+        "Awsi Rasu"
     ],
     "name:pol_x_preferred":[
         "Strefa 1"
     ],
     "name:zho_x_preferred":[
         "\u7b2c\u4e00\u5730\u533a"
+    ],
+    "name:zul_x_preferred":[
+        "Awsi Rasu"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -95,7 +113,7 @@
         }
     ],
     "wof:id":1108695243,
-    "wof:lastmodified":1566593396,
+    "wof:lastmodified":1690879612,
     "wof:name":"Afar Zone 1",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/524/5/1108695245.geojson
+++ b/data/110/869/524/5/1108695245.geojson
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cat_x_preferred":[
+        "Kilbet Rasu"
+    ],
     "name:eng_x_preferred":[
         "Afar Zone 2"
     ],
@@ -47,14 +50,23 @@
     "name:fra_x_preferred":[
         "Zone 2"
     ],
+    "name:fra_x_variant":[
+        "Kilbet Resu"
+    ],
     "name:hrv_x_preferred":[
         "Upravna zona 2"
+    ],
+    "name:ita_x_preferred":[
+        "Kilbati"
     ],
     "name:pol_x_preferred":[
         "Strefa 2"
     ],
     "name:zho_x_preferred":[
         "\u7b2c\u4e8c\u5730\u533a"
+    ],
+    "name:zul_x_preferred":[
+        "Kilbet Rasu"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -92,7 +104,7 @@
         }
     ],
     "wof:id":1108695245,
-    "wof:lastmodified":1566593396,
+    "wof:lastmodified":1690879613,
     "wof:name":"Afar Zone 2",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/524/7/1108695247.geojson
+++ b/data/110/869/524/7/1108695247.geojson
@@ -47,14 +47,23 @@
     "name:fra_x_preferred":[
         "Zone 3"
     ],
+    "name:fra_x_variant":[
+        "Gabi Resu"
+    ],
     "name:hrv_x_preferred":[
         "Upravna zona 3"
+    ],
+    "name:ita_x_preferred":[
+        "Gabi"
     ],
     "name:swe_x_preferred":[
         "Administrative Zone 3"
     ],
     "name:zho_x_preferred":[
         "\u7b2c\u4e09\u5730\u533a"
+    ],
+    "name:zul_x_preferred":[
+        "Gabi Rasu"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":1108695247,
-    "wof:lastmodified":1566593396,
+    "wof:lastmodified":1690879612,
     "wof:name":"Afar Zone 3",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/525/1/1108695251.geojson
+++ b/data/110/869/525/1/1108695251.geojson
@@ -33,6 +33,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cat_x_preferred":[
+        "Fantena Rasu"
+    ],
     "name:eng_x_preferred":[
         "Afar Zone 4"
     ],
@@ -47,11 +50,20 @@
     "name:fra_x_preferred":[
         "Zone 4"
     ],
+    "name:fra_x_variant":[
+        "Fenti Resu"
+    ],
     "name:hrv_x_preferred":[
         "Upravna zona 4"
     ],
+    "name:ita_x_preferred":[
+        "Fanti"
+    ],
     "name:zho_x_preferred":[
         "\u7b2c\u56db\u5730\u533a"
+    ],
+    "name:zul_x_preferred":[
+        "Fantena Rasu"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -89,7 +101,7 @@
         }
     ],
     "wof:id":1108695251,
-    "wof:lastmodified":1566593394,
+    "wof:lastmodified":1690879610,
     "wof:name":"Afar Zone 4",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/525/3/1108695253.geojson
+++ b/data/110/869/525/3/1108695253.geojson
@@ -47,11 +47,20 @@
     "name:fra_x_preferred":[
         "Zone 5"
     ],
+    "name:fra_x_variant":[
+        "Hari Resu"
+    ],
     "name:hrv_x_preferred":[
         "Upravna zona 5"
     ],
+    "name:ita_x_preferred":[
+        "Hari"
+    ],
     "name:zho_x_preferred":[
         "\u7b2c\u4e94\u5730\u533a"
+    ],
+    "name:zul_x_preferred":[
+        "Hari Rasu"
     ],
     "src:geom":"meso",
     "src:lbl_centroid":"mapshaper",
@@ -89,7 +98,7 @@
         }
     ],
     "wof:id":1108695253,
-    "wof:lastmodified":1566593394,
+    "wof:lastmodified":1690879611,
     "wof:name":"Afar Zone 5",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/112/576/983/5/1125769835.geojson
+++ b/data/112/576/983/5/1125769835.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Huruta"
+    ],
     "name:bul_x_preferred":[
         "\u0425\u0443\u0440\u0443\u0442\u0430"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:und_x_variant":[
         "Uruta Mariam"
+    ],
+    "name:zul_x_preferred":[
+        "Huruta"
     ],
     "qs_pg:aaroncc":"ET",
     "qs_pg:gn_country":"ET",
@@ -82,7 +88,7 @@
         }
     ],
     "wof:id":1125769835,
-    "wof:lastmodified":1566593568,
+    "wof:lastmodified":1690879638,
     "wof:name":"Huruta",
     "wof:parent_id":1108695131,
     "wof:placetype":"locality",

--- a/data/112/581/916/3/1125819163.geojson
+++ b/data/112/581/916/3/1125819163.geojson
@@ -22,10 +22,16 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Turmi"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0443\u0440\u043c\u0438"
     ],
     "name:ceb_x_preferred":[
+        "Turmi"
+    ],
+    "name:ces_x_preferred":[
         "Turmi"
     ],
     "name:deu_x_preferred":[
@@ -57,6 +63,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5716\u723e\u7c73"
+    ],
+    "name:zul_x_preferred":[
+        "Turmi"
     ],
     "qs_pg:aaroncc":"ET",
     "qs_pg:gn_country":"ET",
@@ -97,7 +106,7 @@
         }
     ],
     "wof:id":1125819163,
-    "wof:lastmodified":1566593568,
+    "wof:lastmodified":1690879638,
     "wof:name":"Turmi",
     "wof:parent_id":1108695219,
     "wof:placetype":"locality",

--- a/data/112/581/916/9/1125819169.geojson
+++ b/data/112/581/916/9/1125819169.geojson
@@ -22,6 +22,9 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"Quattroshapes Point Gazetteer import 20170519",
+    "name:ast_x_preferred":[
+        "Nejo"
+    ],
     "name:ceb_x_preferred":[
         "Nejo"
     ],
@@ -37,6 +40,9 @@
     "name:nld_x_preferred":[
         "Nejo"
     ],
+    "name:pol_x_preferred":[
+        "Nejo"
+    ],
     "name:swe_x_preferred":[
         "Nejo"
     ],
@@ -45,6 +51,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5167\u55ac"
+    ],
+    "name:zul_x_preferred":[
+        "Nejo"
     ],
     "qs_pg:aaroncc":"ET",
     "qs_pg:gn_country":"ET",
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":1125819169,
-    "wof:lastmodified":1566593568,
+    "wof:lastmodified":1690879638,
     "wof:name":"Nejo",
     "wof:parent_id":1108695233,
     "wof:placetype":"locality",

--- a/data/112/586/154/1/1125861541.geojson
+++ b/data/112/586/154/1/1125861541.geojson
@@ -28,7 +28,13 @@
     "name:ceb_x_preferred":[
         "Korem"
     ],
+    "name:deu_x_preferred":[
+        "Korem"
+    ],
     "name:eng_x_preferred":[
+        "Korem"
+    ],
+    "name:fin_x_preferred":[
         "Korem"
     ],
     "name:fra_x_preferred":[
@@ -38,6 +44,9 @@
         "\u30b3\u30ec\u30e0"
     ],
     "name:nld_x_preferred":[
+        "Korem"
+    ],
+    "name:pol_x_preferred":[
         "Korem"
     ],
     "name:swe_x_preferred":[
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":1125861541,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879637,
     "wof:name":"Korem",
     "wof:parent_id":1108695207,
     "wof:placetype":"locality",

--- a/data/112/586/155/5/1125861555.geojson
+++ b/data/112/586/155/5/1125861555.geojson
@@ -34,7 +34,13 @@
     "name:fra_x_preferred":[
         "Gelemso"
     ],
+    "name:ita_x_preferred":[
+        "Ghelems\u00f2"
+    ],
     "name:nld_x_preferred":[
+        "Gelemso"
+    ],
+    "name:pol_x_preferred":[
         "Gelemso"
     ],
     "name:swe_x_preferred":[
@@ -42,6 +48,9 @@
     ],
     "name:und_x_variant":[
         "Galamso"
+    ],
+    "name:zul_x_preferred":[
+        "Gelemso"
     ],
     "qs_pg:aaroncc":"ET",
     "qs_pg:gn_country":"ET",
@@ -82,7 +91,7 @@
         }
     ],
     "wof:id":1125861555,
-    "wof:lastmodified":1566593568,
+    "wof:lastmodified":1690879638,
     "wof:name":"Gelemso",
     "wof:parent_id":1108695227,
     "wof:placetype":"locality",

--- a/data/112/586/156/5/1125861565.geojson
+++ b/data/112/586/156/5/1125861565.geojson
@@ -28,8 +28,17 @@
     "name:ara_x_preferred":[
         "\u0628\u064a\u0634\u0648\u0641\u062a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u064a\u0634\u0648\u0641\u062a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Bishoftu"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u0438\u0448\u043e\u0444\u0442\u0443"
+    ],
+    "name:cat_x_preferred":[
+        "Bishoftu"
     ],
     "name:ceb_x_preferred":[
         "Bishoftu"
@@ -40,6 +49,9 @@
     "name:deu_x_preferred":[
         "Debre Zeyit"
     ],
+    "name:deu_x_variant":[
+        "Bishoftu"
+    ],
     "name:eng_x_preferred":[
         "Debre Zeyit"
     ],
@@ -49,11 +61,17 @@
     "name:epo_x_preferred":[
         "Debre Zejit"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u06cc\u0634\u0648\u0641\u062a\u0648"
+    ],
     "name:fin_x_preferred":[
         "Debre Zeit"
     ],
     "name:fra_x_preferred":[
         "Debre Zeit"
+    ],
+    "name:fra_x_variant":[
+        "Bishoftu"
     ],
     "name:heb_x_preferred":[
         "\u05d3\u05d1\u05e8\u05d4 \u05d6\u05d9\u05ea"
@@ -70,6 +88,9 @@
     "name:ita_x_preferred":[
         "Bishoftu"
     ],
+    "name:ita_x_variant":[
+        "Biscioft\u00f9"
+    ],
     "name:jpn_x_preferred":[
         "\u30c7\u30d6\u30ec\u30fb\u30bc\u30a4\u30c8"
     ],
@@ -78,6 +99,9 @@
     ],
     "name:nld_x_preferred":[
         "Debre Zeit"
+    ],
+    "name:nob_x_preferred":[
+        "Bishoftu"
     ],
     "name:orm_x_preferred":[
         "Bishooftuu"
@@ -94,11 +118,26 @@
     "name:spa_x_preferred":[
         "Bishoftu"
     ],
+    "name:swa_x_preferred":[
+        "Bishoftu"
+    ],
     "name:swe_x_preferred":[
         "Debre Zeit"
     ],
+    "name:swe_x_variant":[
+        "Debre Zeyt"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0414\u0435\u0431\u0440\u0435-\u0417\u0435\u0439\u0442"
+    ],
+    "name:vie_x_preferred":[
+        "Bishoftu"
+    ],
     "name:zho_x_preferred":[
         "\u5fb7\u5e03\u96f7\u585e\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Bishoftu"
     ],
     "qs_pg:aaroncc":"ET",
     "qs_pg:gn_country":"ET",
@@ -139,7 +178,7 @@
         }
     ],
     "wof:id":1125861565,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879637,
     "wof:name":"Debre Zeyit",
     "wof:parent_id":1108695157,
     "wof:placetype":"locality",

--- a/data/112/593/165/1/1125931651.geojson
+++ b/data/112/593/165/1/1125931651.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_preferred":[
         "\u0634\u0627\u0634\u0627\u0645\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0634\u0627\u0634\u0627\u0645\u0627\u0646"
+    ],
+    "name:ast_x_preferred":[
+        "Shashamane"
+    ],
     "name:bel_x_preferred":[
         "\u0428\u0430\u0448\u044d\u043c\u044d\u043d\u044d"
     ],
@@ -51,6 +57,9 @@
     ],
     "name:epo_x_preferred":[
         "\u015ca\u015damane"
+    ],
+    "name:fas_x_preferred":[
+        "\u0634\u0627\u0634\u0627\u0645\u0627\u0646\u0647"
     ],
     "name:fin_x_preferred":[
         "Shashamane"
@@ -127,6 +136,9 @@
     "name:spa_x_preferred":[
         "Shashamane"
     ],
+    "name:swa_x_preferred":[
+        "Shashamane"
+    ],
     "name:swe_x_preferred":[
         "Shashemene"
     ],
@@ -149,6 +161,12 @@
         "\u0634\u0627\u0634\u0627\u0645\u0627\u0646\u06cc"
     ],
     "name:vie_x_preferred":[
+        "Shashamane"
+    ],
+    "name:zho_x_preferred":[
+        "\u6c99\u820d\u6469\u5167"
+    ],
+    "name:zul_x_preferred":[
         "Shashamane"
     ],
     "qs_pg:aaroncc":"ET",
@@ -190,7 +208,7 @@
         }
     ],
     "wof:id":1125931651,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879637,
     "wof:name":"Shashemen\u0113",
     "wof:parent_id":1108695157,
     "wof:placetype":"locality",

--- a/data/112/593/168/3/1125931683.geojson
+++ b/data/112/593/168/3/1125931683.geojson
@@ -25,6 +25,12 @@
     "name:amh_x_preferred":[
         "\u12f0\u1265\u1228 \u1273\u1266\u122d"
     ],
+    "name:ara_x_preferred":[
+        "\u062f\u064a\u0628\u0631\u064a \u062a\u0627\u0628\u0648\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0628\u0631\u0649 \u062a\u0627\u0628\u0648\u0631"
+    ],
     "name:ceb_x_preferred":[
         "Debre Tabor"
     ],
@@ -34,6 +40,12 @@
     "name:eng_x_preferred":[
         "Debre Tabor"
     ],
+    "name:fas_x_preferred":[
+        "\u062f\u0628\u0631\u0647 \u062a\u0627\u0628\u0648\u0631"
+    ],
+    "name:fin_x_preferred":[
+        "Debre Tabor"
+    ],
     "name:fra_x_preferred":[
         "Debre Tabor"
     ],
@@ -41,6 +53,9 @@
         "\u05d3\u05d1\u05e8\u05d4 \u05ea\u05d1\u05d5\u05e8"
     ],
     "name:hrv_x_preferred":[
+        "Debre Tabor"
+    ],
+    "name:ind_x_preferred":[
         "Debre Tabor"
     ],
     "name:ita_x_preferred":[
@@ -72,6 +87,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5fb7\u535c\u52d2\u5854\u535a\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Debre Tabor"
     ],
     "qs_pg:aaroncc":"ET",
     "qs_pg:gn_country":"ET",
@@ -112,7 +130,7 @@
         }
     ],
     "wof:id":1125931683,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879637,
     "wof:name":"Debre Tabor",
     "wof:parent_id":1108695205,
     "wof:placetype":"locality",

--- a/data/114/190/783/5/1141907835.geojson
+++ b/data/114/190/783/5/1141907835.geojson
@@ -24,6 +24,12 @@
     "name:ara_x_preferred":[
         "\u0622\u062f\u064a\u063a\u0631\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u062f\u064a\u062c\u0631\u0627\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Adigrat"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u06cc\u0642\u0631\u0627\u062a"
     ],
@@ -123,6 +129,9 @@
     "name:spa_x_preferred":[
         "Adigrat"
     ],
+    "name:swa_x_preferred":[
+        "Adigrat"
+    ],
     "name:swe_x_preferred":[
         "Adigrat"
     ],
@@ -152,6 +161,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u8fea\u683c\u62c9\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Adigrat"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -272,7 +284,7 @@
         }
     ],
     "wof:id":1141907835,
-    "wof:lastmodified":1636503454,
+    "wof:lastmodified":1690879640,
     "wof:name":"Adigrat",
     "wof:parent_id":1108695161,
     "wof:placetype":"locality",

--- a/data/114/190/783/9/1141907839.geojson
+++ b/data/114/190/783/9/1141907839.geojson
@@ -27,6 +27,9 @@
     "name:ara_x_variant":[
         "\u0646\u0642\u0645\u062a\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0642\u0645\u062a\u0649"
+    ],
     "name:bar_x_preferred":[
         "Nekemte"
     ],
@@ -44,6 +47,9 @@
     ],
     "name:eng_x_preferred":[
         "Nekemte"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u06a9\u0645\u062a\u0647"
     ],
     "name:fin_x_preferred":[
         "Nekemte"
@@ -120,6 +126,9 @@
     "name:spa_x_preferred":[
         "Nekemte"
     ],
+    "name:swa_x_preferred":[
+        "Nek'emte"
+    ],
     "name:swe_x_preferred":[
         "Nekemte"
     ],
@@ -142,6 +151,12 @@
         "\u0646\u06cc\u06a9\u06cc\u0645\u062a\u06cc"
     ],
     "name:vie_x_preferred":[
+        "Nekemte"
+    ],
+    "name:yue_x_preferred":[
+        "Nekemte"
+    ],
+    "name:zul_x_preferred":[
         "Nekemte"
     ],
     "ne:ADM0CAP":0.0,
@@ -263,7 +278,7 @@
         }
     ],
     "wof:id":1141907839,
-    "wof:lastmodified":1636503453,
+    "wof:lastmodified":1690879640,
     "wof:name":"Nekemte",
     "wof:parent_id":1108695163,
     "wof:placetype":"locality",

--- a/data/114/190/896/7/1141908967.geojson
+++ b/data/114/190/896/7/1141908967.geojson
@@ -24,6 +24,12 @@
     "name:ara_x_preferred":[
         "\u0633\u0648\u062f\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0648\u062f\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Sodo"
+    ],
     "name:ben_x_preferred":[
         "\u09b8\u09cb\u09a1\u09c1"
     ],
@@ -41,6 +47,9 @@
     ],
     "name:eng_x_preferred":[
         "Sodo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u0648\u062f\u0648"
     ],
     "name:fin_x_preferred":[
         "Sodo"
@@ -143,6 +152,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7d22\u591a"
+    ],
+    "name:zul_x_preferred":[
+        "Sodo"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -263,7 +275,7 @@
         }
     ],
     "wof:id":1141908967,
-    "wof:lastmodified":1636503454,
+    "wof:lastmodified":1690879641,
     "wof:name":"Sodo",
     "wof:parent_id":1108695237,
     "wof:placetype":"locality",

--- a/data/114/190/897/1/1141908971.geojson
+++ b/data/114/190/897/1/1141908971.geojson
@@ -21,6 +21,12 @@
     "name:ara_x_preferred":[
         "\u063a\u0648\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u062f\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Gode"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09cb\u09a1\u09c7"
     ],
@@ -114,6 +120,9 @@
     "name:spa_x_preferred":[
         "Gode"
     ],
+    "name:swa_x_preferred":[
+        "Gode"
+    ],
     "name:swe_x_preferred":[
         "Gode"
     ],
@@ -140,6 +149,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6208\u5fb7"
+    ],
+    "name:zul_x_preferred":[
+        "Gode"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -260,7 +272,7 @@
         }
     ],
     "wof:id":1141908971,
-    "wof:lastmodified":1636503454,
+    "wof:lastmodified":1690879641,
     "wof:name":"Gode",
     "wof:parent_id":421200119,
     "wof:placetype":"locality",

--- a/data/421/167/079/421167079.geojson
+++ b/data/421/167/079/421167079.geojson
@@ -29,8 +29,17 @@
     "name:heb_x_preferred":[
         "\u05d2\u05d9\u05d3\u05d5\u05dc\u05d4"
     ],
+    "name:jpn_x_preferred":[
+        "\u30ae\u30c9\u30ec"
+    ],
     "name:nld_x_preferred":[
         "Gidole"
+    ],
+    "name:pol_x_preferred":[
+        "Gidole"
+    ],
+    "name:rus_x_preferred":[
+        "\u0413\u0438\u0434\u043e\u043b\u0435"
     ],
     "name:swe_x_preferred":[
         "G\u012bdol\u0113"
@@ -89,7 +98,7 @@
         }
     ],
     "wof:id":421167079,
-    "wof:lastmodified":1566593552,
+    "wof:lastmodified":1690879615,
     "wof:name":"Gidole",
     "wof:parent_id":1108695151,
     "wof:placetype":"locality",

--- a/data/421/167/081/421167081.geojson
+++ b/data/421/167/081/421167081.geojson
@@ -29,6 +29,9 @@
     "name:nld_x_preferred":[
         "Gebre Guracha"
     ],
+    "name:pol_x_preferred":[
+        "Gebre Guracha"
+    ],
     "name:swe_x_preferred":[
         "Gebre Guracha"
     ],
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":421167081,
-    "wof:lastmodified":1566593552,
+    "wof:lastmodified":1690879615,
     "wof:name":"Gebre Guracha",
     "wof:parent_id":1108695199,
     "wof:placetype":"locality",

--- a/data/421/167/085/421167085.geojson
+++ b/data/421/167/085/421167085.geojson
@@ -32,6 +32,9 @@
     "name:und_x_variant":[
         "Dingab"
     ],
+    "name:zul_x_preferred":[
+        "Dejen"
+    ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":339551,
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":421167085,
-    "wof:lastmodified":1566593552,
+    "wof:lastmodified":1690879615,
     "wof:name":"Dejen",
     "wof:parent_id":1108695153,
     "wof:placetype":"locality",

--- a/data/421/167/839/421167839.geojson
+++ b/data/421/167/839/421167839.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Dodola"
+    ],
     "name:ceb_x_preferred":[
         "Dodola"
     ],
@@ -24,6 +27,9 @@
         "Dodola"
     ],
     "name:fra_x_preferred":[
+        "Dodola"
+    ],
+    "name:ita_x_preferred":[
         "Dodola"
     ],
     "name:jpn_x_preferred":[
@@ -49,6 +55,9 @@
     ],
     "name:zho_x_preferred":[
         "\u591a\u591a\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Dodola"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -100,7 +109,7 @@
         }
     ],
     "wof:id":421167839,
-    "wof:lastmodified":1566593553,
+    "wof:lastmodified":1690879616,
     "wof:name":"Dodola",
     "wof:parent_id":1108695137,
     "wof:placetype":"locality",

--- a/data/421/168/695/421168695.geojson
+++ b/data/421/168/695/421168695.geojson
@@ -26,6 +26,9 @@
     "name:ceb_x_preferred":[
         "Waliso"
     ],
+    "name:deu_x_preferred":[
+        "Waliso"
+    ],
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03b9\u03b3\u03b9\u03cc\u03bd"
     ],
@@ -77,6 +80,9 @@
     "name:spa_x_preferred":[
         "Giyon"
     ],
+    "name:swa_x_preferred":[
+        "Waliso"
+    ],
     "name:swe_x_preferred":[
         "Waliso"
     ],
@@ -97,6 +103,9 @@
     ],
     "name:zho_tw_x_preferred":[
         "\u5409\u6c38"
+    ],
+    "name:zul_x_preferred":[
+        "Waliso"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -237,7 +246,7 @@
         }
     ],
     "wof:id":421168695,
-    "wof:lastmodified":1636503446,
+    "wof:lastmodified":1690879614,
     "wof:name":"Giyon",
     "wof:parent_id":1108695211,
     "wof:placetype":"locality",

--- a/data/421/169/369/421169369.geojson
+++ b/data/421/169/369/421169369.geojson
@@ -20,6 +20,9 @@
     "name:amh_x_preferred":[
         "\u12f0\u1265\u1228 \u12c8\u122d\u1245"
     ],
+    "name:ceb_x_preferred":[
+        "Debre Werk'"
+    ],
     "name:eng_x_preferred":[
         "Debre Work"
     ],
@@ -29,8 +32,14 @@
     "name:nld_x_preferred":[
         "Debre Werq"
     ],
+    "name:swe_x_preferred":[
+        "Debre Werk'"
+    ],
     "name:und_x_variant":[
         "Dabra-Warq"
+    ],
+    "name:zul_x_preferred":[
+        "Debre Werq"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -79,7 +88,7 @@
         }
     ],
     "wof:id":421169369,
-    "wof:lastmodified":1566593553,
+    "wof:lastmodified":1690879616,
     "wof:name":"Debre Werk'",
     "wof:parent_id":1108695153,
     "wof:placetype":"locality",

--- a/data/421/170/391/421170391.geojson
+++ b/data/421/170/391/421170391.geojson
@@ -40,11 +40,17 @@
     "name:arg_x_preferred":[
         "Addis Abeba"
     ],
+    "name:ary_x_preferred":[
+        "\u0623\u062f\u064a\u0633 \u0623\u0628\u0627\u0628\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u062f\u064a\u0633 \u0627\u0628\u0627\u0628\u0627"
     ],
     "name:ast_x_preferred":[
         "Ad\u00eds Abeba"
+    ],
+    "name:avk_x_preferred":[
+        "Addis Ababa"
     ],
     "name:azb_x_preferred":[
         "\u0622\u062f\u06cc\u0633\u200c\u0622\u0628\u0627\u0628\u0627"
@@ -54,6 +60,9 @@
     ],
     "name:bak_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:ban_x_preferred":[
+        "Addis Ababa"
     ],
     "name:bcl_x_preferred":[
         "Addis Ababa"
@@ -89,6 +98,9 @@
         "Addis Abeba"
     ],
     "name:che_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:chv_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
     ],
     "name:ckb_x_preferred":[
@@ -205,6 +217,9 @@
     "name:ina_x_preferred":[
         "Addis Ababa"
     ],
+    "name:ina_x_variant":[
+        "Addis Abeba"
+    ],
     "name:ind_x_preferred":[
         "Addis Ababa"
     ],
@@ -283,6 +298,9 @@
     "name:mar_x_preferred":[
         "\u0905\u0926\u093f\u0938 \u0905\u092c\u093e\u092c\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u0410\u0434\u044b\u0441-\u0410\u0431\u044d\u0431\u0430"
+    ],
     "name:mhr_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
     ],
@@ -313,6 +331,9 @@
     "name:nan_x_preferred":[
         "Addis Abeba"
     ],
+    "name:nav_x_preferred":[
+        "T\u00f3 Sido H\u00e1\u00e1l\u012f\u0301"
+    ],
     "name:new_x_preferred":[
         "\u0905\u0926\u093f\u0938 \u0905\u092c\u093e\u092c\u093e"
     ],
@@ -331,6 +352,9 @@
     "name:nov_x_preferred":[
         "Adis Ababa"
     ],
+    "name:nqo_x_preferred":[
+        "\u07ca\u07d8\u07cc\u07db-\u07ca\u07d3\u07cb\u07d3\u07ca\u07eb"
+    ],
     "name:oci_x_preferred":[
         "Addis Abeba"
     ],
@@ -339,6 +363,9 @@
     ],
     "name:orm_x_preferred":[
         "Addis Abeba"
+    ],
+    "name:orm_x_variant":[
+        "Finfinne"
     ],
     "name:oss_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u00e6"
@@ -363,6 +390,9 @@
     ],
     "name:por_x_preferred":[
         "Adis Abeba"
+    ],
+    "name:pus_x_preferred":[
+        "\u0622\u062f\u06cc\u0633 \u0622\u0628\u0627\u0628\u0627"
     ],
     "name:que_x_preferred":[
         "Adis Ababa"
@@ -399,6 +429,9 @@
     ],
     "name:sju_x_preferred":[
         "Addis Abeba"
+    ],
+    "name:skr_x_preferred":[
+        "\u0627\u062f\u06cc\u0633 \u0627\u0628\u0627\u0628\u0627"
     ],
     "name:slk_x_preferred":[
         "Addis Abeba"
@@ -469,6 +502,9 @@
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e14\u0e14\u0e34\u0e2a\u0e2d\u0e32\u0e1a\u0e32\u0e1a\u0e32"
     ],
+    "name:tir_x_preferred":[
+        "\u12a3\u12f2\u1235 \u12a3\u1260\u1263"
+    ],
     "name:tuk_x_preferred":[
         "Addis Ababa"
     ],
@@ -498,6 +534,9 @@
     ],
     "name:vie_x_preferred":[
         "Addis Ababa"
+    ],
+    "name:vol_x_preferred":[
+        "Addis Ab\u00e4ba"
     ],
     "name:vro_x_preferred":[
         "Addis Abeba"
@@ -532,6 +571,9 @@
     "name:zho_x_preferred":[
         "\u4e9a\u7684\u65af\u4e9a\u8d1d\u5df4"
     ],
+    "name:zul_x_preferred":[
+        "Addis Ababa"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -558,8 +600,8 @@
     "wof:belongsto":[
         102191573,
         85632257,
-        1108695109,
-        85671149
+        85671149,
+        1108695109
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -595,7 +637,7 @@
         }
     ],
     "wof:id":421170391,
-    "wof:lastmodified":1608688190,
+    "wof:lastmodified":1690879624,
     "wof:megacity":1,
     "wof:name":"Addis Ababa",
     "wof:parent_id":1108695109,

--- a/data/421/173/609/421173609.geojson
+++ b/data/421/173/609/421173609.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_preferred":[
         "\u062c\u0648\u0628\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0628\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Goba"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09cb\u09ac\u09be"
+    ],
+    "name:cat_x_preferred":[
+        "Goba"
     ],
     "name:ceb_x_preferred":[
         "Goba"
@@ -40,6 +49,9 @@
     ],
     "name:fas_x_preferred":[
         "\u06af\u0648\u0628\u0627"
+    ],
+    "name:fin_x_preferred":[
+        "Goba"
     ],
     "name:fra_x_preferred":[
         "Goba"
@@ -89,6 +101,9 @@
     "name:spa_x_preferred":[
         "Goba"
     ],
+    "name:swa_x_preferred":[
+        "Goba"
+    ],
     "name:swe_x_preferred":[
         "Goba"
     ],
@@ -109,6 +124,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6208\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Goba"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -253,7 +271,7 @@
         }
     ],
     "wof:id":421173609,
-    "wof:lastmodified":1636503446,
+    "wof:lastmodified":1690879618,
     "wof:name":"Goba",
     "wof:parent_id":1108695137,
     "wof:placetype":"locality",

--- a/data/421/173/889/421173889.geojson
+++ b/data/421/173/889/421173889.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Mega"
+    ],
     "name:ceb_x_preferred":[
         "M\u0113ga"
     ],
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":421173889,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879618,
     "wof:name":"Mega",
     "wof:parent_id":421188225,
     "wof:placetype":"locality",

--- a/data/421/174/515/421174515.geojson
+++ b/data/421/174/515/421174515.geojson
@@ -23,11 +23,20 @@
     "name:ara_x_preferred":[
         "\u0622\u0645\u0628\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0645\u0628\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Ambo"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0645\u0628\u0648"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09ae\u09cd\u09ac\u09c1"
+    ],
+    "name:cat_x_preferred":[
+        "Ambo"
     ],
     "name:ceb_x_preferred":[
         "H\u0101gere Hiywet"
@@ -116,6 +125,9 @@
     "name:spa_x_preferred":[
         "Ambo"
     ],
+    "name:swa_x_preferred":[
+        "Ambo"
+    ],
     "name:swe_x_preferred":[
         "Ambo"
     ],
@@ -145,6 +157,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5b89\u6ce2"
+    ],
+    "name:zul_x_preferred":[
+        "Ambo"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -285,7 +300,7 @@
         }
     ],
     "wof:id":421174515,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879618,
     "wof:name":"Agere Hiywet",
     "wof:parent_id":1108695239,
     "wof:placetype":"locality",

--- a/data/421/176/867/421176867.geojson
+++ b/data/421/176/867/421176867.geojson
@@ -38,6 +38,9 @@
     "name:und_x_variant":[
         "Sandafe"
     ],
+    "name:zul_x_preferred":[
+        "Sendafa"
+    ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":328880,
@@ -86,7 +89,7 @@
         }
     ],
     "wof:id":421176867,
-    "wof:lastmodified":1566593559,
+    "wof:lastmodified":1690879625,
     "wof:name":"Sendafa",
     "wof:parent_id":1108695199,
     "wof:placetype":"locality",

--- a/data/421/176/869/421176869.geojson
+++ b/data/421/176/869/421176869.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Sebeta"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0435\u0431\u0435\u0442\u0430"
     ],
@@ -52,6 +55,9 @@
     ],
     "name:zho_x_preferred":[
         "\u745f\u4f2f\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Sebeta"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -104,7 +110,7 @@
         }
     ],
     "wof:id":421176869,
-    "wof:lastmodified":1566593559,
+    "wof:lastmodified":1690879625,
     "wof:name":"Sebeta",
     "wof:parent_id":1108695211,
     "wof:placetype":"locality",

--- a/data/421/177/291/421177291.geojson
+++ b/data/421/177/291/421177291.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":11.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Were Ilu"
+    ],
     "name:ceb_x_preferred":[
         "Were \u012alu"
     ],
@@ -25,6 +28,9 @@
     ],
     "name:fra_x_preferred":[
         "Were Ilu"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d5\u05d5\u05e8 \u05d0\u05d9\u05dc\u05d5"
     ],
     "name:nld_x_preferred":[
         "Were Ilu"
@@ -88,7 +94,7 @@
         }
     ],
     "wof:id":421177291,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1690879624,
     "wof:name":"Were Ilu",
     "wof:parent_id":1108695209,
     "wof:placetype":"locality",

--- a/data/421/177/891/421177891.geojson
+++ b/data/421/177/891/421177891.geojson
@@ -20,6 +20,12 @@
     "name:amh_x_preferred":[
         "\u134d\u1296\u1270 \u1230\u120b\u121d"
     ],
+    "name:ast_x_preferred":[
+        "Finote Selam"
+    ],
+    "name:cat_x_preferred":[
+        "Finote Selam"
+    ],
     "name:ceb_x_preferred":[
         "Finote Selam"
     ],
@@ -35,6 +41,12 @@
     "name:fra_x_preferred":[
         "Finote Selam"
     ],
+    "name:hau_x_preferred":[
+        "Finote Selam"
+    ],
+    "name:heb_x_preferred":[
+        "\u05e4\u05d9\u05e0\u05d5\u05d8\u05d4 \u05e1\u05dc\u05d0\u05dd"
+    ],
     "name:hun_x_preferred":[
         "Finote Selam"
     ],
@@ -47,6 +59,9 @@
     "name:pol_x_preferred":[
         "Finote Selam"
     ],
+    "name:rus_x_preferred":[
+        "\u0424\u044b\u043d\u043e\u0442\u044d-\u0421\u044d\u043b\u0430\u043c"
+    ],
     "name:swe_x_preferred":[
         "Finote Selam"
     ],
@@ -55,6 +70,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8cbb\u8afe\u7279\u585e\u862d"
+    ],
+    "name:zul_x_preferred":[
+        "Finote Selam"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -107,7 +125,7 @@
         }
     ],
     "wof:id":421177891,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1690879624,
     "wof:name":"Finote Selam",
     "wof:parent_id":1108695223,
     "wof:placetype":"locality",

--- a/data/421/180/431/421180431.geojson
+++ b/data/421/180/431/421180431.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ceb_x_preferred":[
+        "Guder"
+    ],
     "name:eng_x_preferred":[
         "Guder"
     ],
@@ -25,6 +28,12 @@
     ],
     "name:orm_x_preferred":[
         "Gudar"
+    ],
+    "name:pol_x_preferred":[
+        "Guder"
+    ],
+    "name:swe_x_preferred":[
+        "Guder"
     ],
     "name:zho_x_preferred":[
         "\u53e4\u5fb7\u723e"
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":421180431,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879618,
     "wof:name":"Guder",
     "wof:parent_id":1108695239,
     "wof:placetype":"locality",

--- a/data/421/180/433/421180433.geojson
+++ b/data/421/180/433/421180433.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u063a\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0631"
+    ],
     "name:ceb_x_preferred":[
         "Gor\u0113"
     ],
@@ -70,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6208\u96f7"
+    ],
+    "name:zul_x_preferred":[
+        "Gore"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -211,7 +217,7 @@
         }
     ],
     "wof:id":421180433,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879618,
     "wof:name":"Gor\u0113",
     "wof:parent_id":890446963,
     "wof:placetype":"locality",

--- a/data/421/182/273/421182273.geojson
+++ b/data/421/182/273/421182273.geojson
@@ -46,6 +46,9 @@
     "name:fra_x_preferred":[
         "Gurage"
     ],
+    "name:ita_x_preferred":[
+        "Guraghe"
+    ],
     "name:jpn_x_preferred":[
         "\u30b0\u30e9\u30b2\u770c"
     ],
@@ -58,8 +61,14 @@
     "name:swe_x_preferred":[
         "Guraghe Zone"
     ],
+    "name:swe_x_variant":[
+        "Guraghe"
+    ],
     "name:zho_x_preferred":[
         "\u53e4\u62c9\u84cb\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Gurage Zone"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -123,7 +132,7 @@
         }
     ],
     "wof:id":421182273,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879624,
     "wof:name":"Gurage",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/421/182/671/421182671.geojson
+++ b/data/421/182/671/421182671.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0645\u0628\u0648\u0644\u0634\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0645\u0628\u0648\u0644\u0634\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09ae\u09cd\u09ac\u09b2\u0996\u09be"
     ],
@@ -44,6 +47,9 @@
     "name:eng_x_preferred":[
         "Kombolcha"
     ],
+    "name:fas_x_preferred":[
+        "\u06a9\u0648\u0645\u0628\u0648\u0644\u0686\u0627"
+    ],
     "name:fin_x_preferred":[
         "Kombolcha"
     ],
@@ -55,6 +61,9 @@
     ],
     "name:hbs_x_preferred":[
         "Kombol\u010da"
+    ],
+    "name:heb_x_preferred":[
+        "\u05db\u05d5\u05de\u05d1\u05d5\u05dc\u05e6'\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0915\u0949\u092e\u092c\u094b\u0932\u091a\u093e"
@@ -125,6 +134,9 @@
     "name:srp_x_preferred":[
         "Kombol\u010da"
     ],
+    "name:swa_x_preferred":[
+        "Kombolcha"
+    ],
     "name:swe_x_preferred":[
         "Kombolcha"
     ],
@@ -154,6 +166,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5b54\u535a\u52d2\u67e5"
+    ],
+    "name:zul_x_preferred":[
+        "Kombolcha"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -203,7 +218,7 @@
         }
     ],
     "wof:id":421182671,
-    "wof:lastmodified":1566593559,
+    "wof:lastmodified":1690879625,
     "wof:name":"Kembolcha",
     "wof:parent_id":1108695209,
     "wof:placetype":"locality",

--- a/data/421/184/699/421184699.geojson
+++ b/data/421/184/699/421184699.geojson
@@ -37,8 +37,14 @@
     "name:ceb_x_preferred":[
         "Shinile Zone"
     ],
+    "name:ceb_x_variant":[
+        "Sitti Zone"
+    ],
     "name:deu_x_preferred":[
         "Shinile-Zone"
+    ],
+    "name:deu_x_variant":[
+        "Sitti-Zone"
     ],
     "name:eng_x_preferred":[
         "Shinile Zone"
@@ -51,6 +57,12 @@
     "name:fra_x_preferred":[
         "Shinile"
     ],
+    "name:fra_x_variant":[
+        "Sitti"
+    ],
+    "name:ita_x_preferred":[
+        "Siti"
+    ],
     "name:jpn_x_preferred":[
         "\u30b7\u30c3\u30c6\u30a3\u770c"
     ],
@@ -59,6 +71,12 @@
     ],
     "name:swe_x_preferred":[
         "Shinile Zone"
+    ],
+    "name:swe_x_variant":[
+        "Shinile"
+    ],
+    "name:zul_x_preferred":[
+        "Sitti Zone"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"ADM2",
@@ -124,7 +142,7 @@
         }
     ],
     "wof:id":421184699,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879623,
     "wof:name":"Shinile",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/188/225/421188225.geojson
+++ b/data/421/188/225/421188225.geojson
@@ -52,6 +52,9 @@
     "name:ita_x_preferred":[
         "Borana"
     ],
+    "name:ita_x_variant":[
+        "Borena"
+    ],
     "name:orm_x_preferred":[
         "Boorana"
     ],
@@ -61,8 +64,17 @@
     "name:swe_x_preferred":[
         "Borena Zone"
     ],
+    "name:swe_x_variant":[
+        "Borena"
+    ],
     "name:zho_x_preferred":[
         "\u535a\u52d2\u7d0d\u5730\u5340"
+    ],
+    "name:zho_x_variant":[
+        "\u535a\u62c9\u7d0d\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Borena Zone"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -127,7 +139,7 @@
         }
     ],
     "wof:id":421188225,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879620,
     "wof:name":"Borena",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/421/188/343/421188343.geojson
+++ b/data/421/188/343/421188343.geojson
@@ -47,6 +47,9 @@
     "name:nld_x_preferred":[
         "Jijiga"
     ],
+    "name:zul_x_preferred":[
+        "Jijiga"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -109,7 +112,7 @@
         }
     ],
     "wof:id":421188343,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879620,
     "wof:name":"Jijiga",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/189/393/421189393.geojson
+++ b/data/421/189/393/421189393.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_variant":[
         "\u0628\u0627\u062a\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u062a\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Bati"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09be\u09a4\u09bf"
     ],
@@ -106,6 +112,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u63d0"
+    ],
+    "name:zul_x_preferred":[
+        "Bati"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -250,7 +259,7 @@
         }
     ],
     "wof:id":421189393,
-    "wof:lastmodified":1636503446,
+    "wof:lastmodified":1690879619,
     "wof:name":"Bati",
     "wof:parent_id":1108695203,
     "wof:placetype":"locality",

--- a/data/421/189/649/421189649.geojson
+++ b/data/421/189/649/421189649.geojson
@@ -23,6 +23,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0627\u0633\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0627\u0633\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Hawaasa"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u0993\u09af\u09bc\u09be\u09b8\u09be"
     ],
@@ -44,11 +50,17 @@
     "name:deu_x_preferred":[
         "Awassa"
     ],
+    "name:deu_x_variant":[
+        "Awasa"
+    ],
     "name:ell_x_preferred":[
         "\u0391\u03bf\u03c5\u03ac\u03c3\u03b1"
     ],
     "name:eng_x_preferred":[
         "Awasa"
+    ],
+    "name:eng_x_variant":[
+        "Hawaasa"
     ],
     "name:epo_x_preferred":[
         "A\u016dasa"
@@ -56,11 +68,20 @@
     "name:eus_x_preferred":[
         "Awasa"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u0648\u0627\u0633\u0627"
+    ],
     "name:fin_x_preferred":[
         "Awasa"
     ],
     "name:fra_x_preferred":[
         "Awasa"
+    ],
+    "name:fra_x_variant":[
+        "Hawassa"
+    ],
+    "name:gle_x_preferred":[
+        "Hawaasa"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab5\u0abe\u0ab8\u0abe"
@@ -80,6 +101,9 @@
     "name:hun_x_preferred":[
         "Awassa"
     ],
+    "name:hye_x_preferred":[
+        "\u0531\u0578\u0582\u0561\u057d\u0561"
+    ],
     "name:ind_x_preferred":[
         "Awasa"
     ],
@@ -88,6 +112,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30ef\u30b5"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30ef\u30c3\u30b5"
     ],
     "name:kan_x_preferred":[
         "\u0c85\u0cb5\u0cbe\u0cb8\u0cbe"
@@ -118,6 +145,9 @@
     ],
     "name:oci_x_preferred":[
         "Awasa"
+    ],
+    "name:orm_x_preferred":[
+        "Hawaasa"
     ],
     "name:pol_x_preferred":[
         "Auasa"
@@ -164,11 +194,20 @@
     "name:urd_x_preferred":[
         "\u0627\u0648\u0627\u0633\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Auasa"
+    ],
     "name:vie_x_preferred":[
         "Awasa"
     ],
+    "name:war_x_preferred":[
+        "Hawassa"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u74e6\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Awasa"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -218,7 +257,7 @@
         }
     ],
     "wof:id":421189649,
-    "wof:lastmodified":1566593555,
+    "wof:lastmodified":1690879619,
     "wof:name":"Awasa",
     "wof:parent_id":421204421,
     "wof:placetype":"locality",

--- a/data/421/189/651/421189651.geojson
+++ b/data/421/189/651/421189651.geojson
@@ -29,6 +29,12 @@
     "name:ara_x_preferred":[
         "\u0628\u062d\u0631 \u062f\u0627\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u062d\u0631 \u062f\u0627\u0631"
+    ],
+    "name:ast_x_preferred":[
+        "Bahir Dar"
+    ],
     "name:bel_x_preferred":[
         "\u0411\u0430\u0445\u0440-\u0414\u0430\u0440"
     ],
@@ -62,11 +68,17 @@
     "name:eus_x_preferred":[
         "Bahir Dar"
     ],
+    "name:fas_x_preferred":[
+        "\u0628\u0647\u06cc\u0631 \u062f\u0627\u0631"
+    ],
     "name:fin_x_preferred":[
         "Bahir Dar"
     ],
     "name:fra_x_preferred":[
         "Baher Dar"
+    ],
+    "name:gle_x_preferred":[
+        "Bahir Dar"
     ],
     "name:guj_x_preferred":[
         "\u0aac\u0ab9\u0abf\u0ab0 \u0aa6\u0abe\u0ab0"
@@ -155,6 +167,9 @@
     "name:srp_x_preferred":[
         "\u0411\u0430\u0445\u0438\u0440 \u0414\u0430\u0440"
     ],
+    "name:swa_x_preferred":[
+        "Bahir Dar"
+    ],
     "name:swe_x_preferred":[
         "Bahir Dar"
     ],
@@ -179,6 +194,9 @@
     "name:urd_x_preferred":[
         "\u0628\u062d\u0631 \u062f\u0627\u0631"
     ],
+    "name:vec_x_preferred":[
+        "Bahar Dar"
+    ],
     "name:vep_x_preferred":[
         "Bahr Dar"
     ],
@@ -190,6 +208,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5df4\u8d6b\u9054\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Bahir Dar"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -243,7 +264,7 @@
         }
     ],
     "wof:id":421189651,
-    "wof:lastmodified":1566593555,
+    "wof:lastmodified":1690879619,
     "wof:name":"Bahir Dar",
     "wof:parent_id":1108695135,
     "wof:placetype":"locality",

--- a/data/421/189/653/421189653.geojson
+++ b/data/421/189/653/421189653.geojson
@@ -6,7 +6,7 @@
     "edtf:inception":"uuuu",
     "geom:area":0.0,
     "geom:area_square_m":0.0,
-    "geom:bbox":"34.590977,8.2443365,34.590977,8.2443365",
+    "geom:bbox":"34.590977,8.244336,34.590977,8.244336",
     "geom:latitude":8.244336,
     "geom:longitude":34.590977,
     "iso:country":"ET",
@@ -26,6 +26,12 @@
     "name:ara_x_variant":[
         "\u063a\u0627\u0645\u0628\u064a\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0645\u0628\u064a\u0644\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Gambela"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09be\u09ae\u09cd\u09ac\u09c7\u09b2\u09be"
     ],
@@ -43,6 +49,12 @@
     ],
     "name:eng_x_preferred":[
         "Gambela"
+    ],
+    "name:epo_x_preferred":[
+        "Gambelo"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0627\u0645\u0628\u0644\u0627"
     ],
     "name:fin_x_preferred":[
         "Gambela"
@@ -149,6 +161,9 @@
     "name:zho_x_preferred":[
         "\u7518\u8d1d\u62c9"
     ],
+    "name:zul_x_preferred":[
+        "Gambela"
+    ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
     "qs:gn_id":0,
@@ -183,7 +198,7 @@
     },
     "wof:country":"ET",
     "wof:created":1459009631,
-    "wof:geomhash":"e514f1e2b0aaa956f95e5370fedd633e",
+    "wof:geomhash":"c3fe14593653af1978f23521befcaa07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -194,7 +209,7 @@
         }
     ],
     "wof:id":421189653,
-    "wof:lastmodified":1566593555,
+    "wof:lastmodified":1690879619,
     "wof:name":"Gambela",
     "wof:parent_id":421188217,
     "wof:placetype":"locality",
@@ -205,9 +220,9 @@
 },
   "bbox": [
     34.590977,
-    8.2443365,
+    8.244336,
     34.590977,
-    8.2443365
+    8.244336
 ],
-  "geometry": {"coordinates":[34.590977,8.2443365],"type":"Point"}
+  "geometry": {"coordinates":[34.590977,8.244336],"type":"Point"}
 }

--- a/data/421/190/257/421190257.geojson
+++ b/data/421/190/257/421190257.geojson
@@ -40,8 +40,17 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0631\u0629 \u062f\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0631\u0629 \u062f\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Dire Dawa"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06cc\u0631\u062f\u0627\u0648\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "D\u0131re-Daua"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u044b\u0440\u044d-\u0414\u0430\u0443\u0430"
@@ -51,6 +60,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09a1\u09be\u0987\u09b0\u09c7 \u09a1\u09be\u0993\u09af\u09bc"
+    ],
+    "name:bho_x_preferred":[
+        "\u0921\u093f\u0930\u0947 \u0921\u093e\u0935\u093e"
     ],
     "name:bre_x_preferred":[
         "Dire Dawa"
@@ -97,6 +109,12 @@
     "name:fra_x_preferred":[
         "Dire Dawa"
     ],
+    "name:gle_x_preferred":[
+        "Dire Dawa"
+    ],
+    "name:glg_x_preferred":[
+        "Dire Dawa"
+    ],
     "name:guj_x_preferred":[
         "\u0aa1\u0abf\u0ab0\u0ac7 \u0aa1\u0abe\u0ab5\u0abe"
     ],
@@ -117,6 +135,9 @@
     ],
     "name:hun_x_preferred":[
         "Dire Dawa"
+    ],
+    "name:hye_x_preferred":[
+        "\u0534\u056b\u0580\u0565 \u0534\u0561\u0578\u0582\u0561"
     ],
     "name:ind_x_preferred":[
         "Dire Dawa"
@@ -226,14 +247,23 @@
     "name:uzb_x_preferred":[
         "Diredava"
     ],
+    "name:vec_x_preferred":[
+        "Dire Daua"
+    ],
     "name:vie_x_preferred":[
         "Dire Dawa"
     ],
     "name:war_x_preferred":[
         "Dire Dawa"
     ],
+    "name:wuu_x_preferred":[
+        "\u5fb7\u96f7\u8fbe\u74e6"
+    ],
     "name:zho_x_preferred":[
         "\u5fb7\u96f7\u8fbe\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Dire Dawa"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"ADM2",
@@ -302,7 +332,7 @@
         }
     ],
     "wof:id":421190257,
-    "wof:lastmodified":1607993768,
+    "wof:lastmodified":1690879621,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85671159,
     "wof:placetype":"county",

--- a/data/421/190/907/421190907.geojson
+++ b/data/421/190/907/421190907.geojson
@@ -20,6 +20,9 @@
     "name:amh_x_preferred":[
         "\u12a0\u134b\u121d\u1266"
     ],
+    "name:cat_x_preferred":[
+        "Afambo"
+    ],
     "name:eng_x_preferred":[
         "Afambo"
     ],
@@ -27,6 +30,9 @@
         "Afambo"
     ],
     "name:hrv_x_preferred":[
+        "Afambo"
+    ],
+    "name:ita_x_preferred":[
         "Afambo"
     ],
     "name:nld_x_preferred":[
@@ -37,6 +43,9 @@
     ],
     "name:und_x_variant":[
         "Afembo"
+    ],
+    "name:zul_x_preferred":[
+        "Afambo"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -84,7 +93,7 @@
         }
     ],
     "wof:id":421190907,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1690879621,
     "wof:name":"Afambo",
     "wof:parent_id":1108695243,
     "wof:placetype":"locality",

--- a/data/421/191/849/421191849.geojson
+++ b/data/421/191/849/421191849.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Ginir"
+    ],
     "name:bul_x_preferred":[
         "\u0413\u0438\u043d\u0438\u0440"
     ],
@@ -32,6 +35,9 @@
     "name:fra_x_preferred":[
         "Ginir"
     ],
+    "name:ita_x_preferred":[
+        "Ghim\u00ecr"
+    ],
     "name:jpn_x_preferred":[
         "\u30ae\u30cb\u30eb"
     ],
@@ -46,6 +52,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u5c3c\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Ginir"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -94,7 +103,7 @@
         }
     ],
     "wof:id":421191849,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1690879621,
     "wof:name":"G\u012bn\u012br",
     "wof:parent_id":1108695137,
     "wof:placetype":"locality",

--- a/data/421/192/777/421192777.geojson
+++ b/data/421/192/777/421192777.geojson
@@ -23,8 +23,17 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0631\u0629 \u062f\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0631\u0629 \u062f\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Dire Dawa"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06cc\u0631\u062f\u0627\u0648\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "D\u0131re-Daua"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0414\u044b\u0440\u044d-\u0414\u0430\u0443\u0430"
@@ -34,6 +43,9 @@
     ],
     "name:ben_x_preferred":[
         "\u09a1\u09be\u0987\u09b0\u09c7 \u09a1\u09be\u0993\u09af\u09bc"
+    ],
+    "name:bho_x_preferred":[
+        "\u0921\u093f\u0930\u0947 \u0921\u093e\u0935\u093e"
     ],
     "name:bre_x_preferred":[
         "Dire Dawa"
@@ -80,6 +92,12 @@
     "name:fra_x_preferred":[
         "Dire Dawa"
     ],
+    "name:gle_x_preferred":[
+        "Dire Dawa"
+    ],
+    "name:glg_x_preferred":[
+        "Dire Dawa"
+    ],
     "name:guj_x_preferred":[
         "\u0aa1\u0abf\u0ab0\u0ac7 \u0aa1\u0abe\u0ab5\u0abe"
     ],
@@ -97,6 +115,9 @@
     ],
     "name:hun_x_preferred":[
         "Dire Dawa"
+    ],
+    "name:hye_x_preferred":[
+        "\u0534\u056b\u0580\u0565 \u0534\u0561\u0578\u0582\u0561"
     ],
     "name:ind_x_preferred":[
         "Dire Dawa"
@@ -212,14 +233,23 @@
     "name:uzb_x_preferred":[
         "Diredava"
     ],
+    "name:vec_x_preferred":[
+        "Dire Daua"
+    ],
     "name:vie_x_preferred":[
         "Dire Dawa"
     ],
     "name:war_x_preferred":[
         "Dire Dawa"
     ],
+    "name:wuu_x_preferred":[
+        "\u5fb7\u96f7\u8fbe\u74e6"
+    ],
     "name:zho_x_preferred":[
         "\u5fb7\u96f7\u8fbe\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Dire Dawa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -359,7 +389,7 @@
         }
     ],
     "wof:id":421192777,
-    "wof:lastmodified":1566593551,
+    "wof:lastmodified":1690879614,
     "wof:name":"Dire Dawa",
     "wof:parent_id":421190257,
     "wof:placetype":"locality",

--- a/data/421/193/231/421193231.geojson
+++ b/data/421/193/231/421193231.geojson
@@ -20,8 +20,17 @@
     "name:amh_x_preferred":[
         "\u12a0\u130b\u122e"
     ],
+    "name:ast_x_preferred":[
+        "Agaro"
+    ],
+    "name:cat_x_preferred":[
+        "Agaro"
+    ],
     "name:ceb_x_preferred":[
         "\u0100garo"
+    ],
+    "name:ces_x_preferred":[
+        "Agaro"
     ],
     "name:deu_x_preferred":[
         "Agaro"
@@ -29,8 +38,17 @@
     "name:eng_x_preferred":[
         "Agaro"
     ],
+    "name:fas_x_preferred":[
+        "\u0622\u06af\u0627\u0631\u0648"
+    ],
     "name:fra_x_preferred":[
         "Agaro"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d4\u05d0\u05d2\u05d2\u05d0\u05e8\u05d5"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0563\u0561\u0580\u0578"
     ],
     "name:ita_x_preferred":[
         "Agaro"
@@ -53,6 +71,9 @@
     "name:spa_x_preferred":[
         "Agaro"
     ],
+    "name:swa_x_preferred":[
+        "Agaro"
+    ],
     "name:swe_x_preferred":[
         "Agaro"
     ],
@@ -61,6 +82,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u52a0\u7f85"
+    ],
+    "name:zul_x_preferred":[
+        "Agaro"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -113,7 +137,7 @@
         }
     ],
     "wof:id":421193231,
-    "wof:lastmodified":1566593552,
+    "wof:lastmodified":1690879615,
     "wof:name":"Agaro",
     "wof:parent_id":890418071,
     "wof:placetype":"locality",

--- a/data/421/195/685/421195685.geojson
+++ b/data/421/195/685/421195685.geojson
@@ -26,14 +26,26 @@
     "name:ara_x_preferred":[
         "\u0647\u0631\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0647\u0631\u0631"
+    ],
     "name:ast_x_preferred":[
         "Harar Jugol"
+    ],
+    "name:avk_x_preferred":[
+        "Harar"
+    ],
+    "name:azb_x_preferred":[
+        "\u0647\u0631\u0631"
     ],
     "name:aze_x_preferred":[
         "Harar"
     ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0425\u0430\u0440\u044d\u0440"
+    ],
+    "name:bel_x_variant":[
+        "\u0425\u0430\u0440\u044d\u0440"
     ],
     "name:ben_x_preferred":[
         "\u09b9\u09be\u09b0\u09be"
@@ -83,8 +95,17 @@
     "name:fra_x_preferred":[
         "Harar"
     ],
+    "name:gle_x_preferred":[
+        "Harar Jugol"
+    ],
+    "name:glg_x_preferred":[
+        "Harar"
+    ],
     "name:guj_x_preferred":[
         "\u0ab9\u0ab0\u0abe\u0ab0"
+    ],
+    "name:hau_x_preferred":[
+        "Harar"
     ],
     "name:hbs_x_preferred":[
         "Harar"
@@ -100,6 +121,9 @@
     ],
     "name:hun_x_preferred":[
         "Harar"
+    ],
+    "name:hye_x_preferred":[
+        "\u0540\u0561\u0580\u0565\u0580"
     ],
     "name:ind_x_preferred":[
         "Harar"
@@ -143,6 +167,9 @@
     "name:nor_x_preferred":[
         "Harar"
     ],
+    "name:nqo_x_preferred":[
+        "\u07e4\u07d9\u07ca\u07d9 \u07d6\u07ce\u07dc\u07ed\u07d0\u07df"
+    ],
     "name:pan_x_preferred":[
         "\u0a39\u0a3e\u0a30\u0a30"
     ],
@@ -173,6 +200,9 @@
     "name:spa_x_preferred":[
         "Harar Jugol"
     ],
+    "name:spa_x_variant":[
+        "Harrar Jugol"
+    ],
     "name:srp_x_preferred":[
         "\u0425\u0430\u0440\u0430\u0440"
     ],
@@ -191,6 +221,9 @@
     "name:tha_x_preferred":[
         "\u0e2e\u0e32\u0e23\u0e32"
     ],
+    "name:tha_x_variant":[
+        "\u0e2e\u0e32\u0e40\u0e23\u0e2d\u0e23\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Harar"
     ],
@@ -203,11 +236,23 @@
     "name:urd_x_preferred":[
         "\u06c1\u0631\u0627\u0631"
     ],
+    "name:vec_x_preferred":[
+        "Harar"
+    ],
     "name:vie_x_preferred":[
         "Harar"
     ],
+    "name:war_x_preferred":[
+        "Harar"
+    ],
+    "name:wuu_x_preferred":[
+        "\u54c8\u52d2\u5c14"
+    ],
     "name:zho_x_preferred":[
         "\u54c8\u52d2\u5c14"
+    ],
+    "name:zul_x_preferred":[
+        "Harar"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -362,7 +407,7 @@
         }
     ],
     "wof:id":421195685,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879615,
     "wof:name":"Harer",
     "wof:parent_id":1108695173,
     "wof:placetype":"locality",

--- a/data/421/196/835/421196835.geojson
+++ b/data/421/196/835/421196835.geojson
@@ -23,7 +23,13 @@
     "name:eng_x_preferred":[
         "Tulu Bolo"
     ],
+    "name:fra_x_preferred":[
+        "Tulu Bolo"
+    ],
     "name:nld_x_preferred":[
+        "Tulu Bolo"
+    ],
+    "name:pol_x_preferred":[
         "Tulu Bolo"
     ],
     "name:rus_x_preferred":[
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":421196835,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1690879621,
     "wof:name":"Tulu Bolo",
     "wof:parent_id":1108695211,
     "wof:placetype":"locality",

--- a/data/421/197/333/421197333.geojson
+++ b/data/421/197/333/421197333.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Shambu"
+    ],
     "name:ceb_x_preferred":[
         "Shambu"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5c71\u5e03"
+    ],
+    "name:zul_x_preferred":[
+        "Shambu"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -89,7 +95,7 @@
         }
     ],
     "wof:id":421197333,
-    "wof:lastmodified":1566593557,
+    "wof:lastmodified":1690879622,
     "wof:name":"Shambu",
     "wof:parent_id":1108695163,
     "wof:placetype":"locality",

--- a/data/421/197/337/421197337.geojson
+++ b/data/421/197/337/421197337.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062c\u064a\u0645\u0628\u064a"
     ],
+    "name:ast_x_preferred":[
+        "Gimbi"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09bf\u09ae\u09cd\u09ac\u09bf"
     ],
@@ -37,6 +40,9 @@
     ],
     "name:eng_x_variant":[
         "Ghimbi"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u06cc\u0645\u0628\u06cc"
     ],
     "name:fra_x_preferred":[
         "Gimbi"
@@ -56,6 +62,9 @@
     "name:ita_x_preferred":[
         "Gimbi"
     ],
+    "name:ita_x_variant":[
+        "Ghimbi"
+    ],
     "name:jpn_x_preferred":[
         "\u30b8\u30f3\u30d3"
     ],
@@ -73,6 +82,9 @@
     ],
     "name:rus_x_preferred":[
         "\u0413\u0438\u043c\u0431\u0438"
+    ],
+    "name:rus_x_variant":[
+        "\u0413\u044b\u043c\u0431\u0438"
     ],
     "name:spa_x_preferred":[
         "Gimbi"
@@ -97,6 +109,9 @@
     ],
     "name:zho_x_preferred":[
         "\u91d1\u6bd4"
+    ],
+    "name:zul_x_preferred":[
+        "Gimbi"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -241,7 +256,7 @@
         }
     ],
     "wof:id":421197337,
-    "wof:lastmodified":1636503447,
+    "wof:lastmodified":1690879621,
     "wof:name":"Gimbi",
     "wof:parent_id":1108695233,
     "wof:placetype":"locality",

--- a/data/421/197/339/421197339.geojson
+++ b/data/421/197/339/421197339.geojson
@@ -26,6 +26,9 @@
     "name:ara_x_variant":[
         "\u062f\u064a\u0644\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Dila"
+    ],
     "name:ben_x_preferred":[
         "\u09a6\u09bf\u09b2\u09be"
     ],
@@ -43,6 +46,9 @@
     ],
     "name:eng_x_preferred":[
         "Dila"
+    ],
+    "name:fas_x_preferred":[
+        "\u062f\u06cc\u0644\u0627"
     ],
     "name:fin_x_preferred":[
         "Dila"
@@ -125,6 +131,9 @@
     "name:sqi_x_preferred":[
         "Dila"
     ],
+    "name:swa_x_preferred":[
+        "Dilla"
+    ],
     "name:swe_x_preferred":[
         "D\u012bla"
     ],
@@ -150,9 +159,13 @@
         "\u062f\u0644\u0627 \u060c \u0627\u06cc\u062a\u06be\u0648\u067e\u06cc\u0627"
     ],
     "name:urd_x_variant":[
-        "\u062f\u0644\u0627"
+        "\u062f\u0644\u0627",
+        "\u062f\u0644\u0627 "
     ],
     "name:vie_x_preferred":[
+        "Dila"
+    ],
+    "name:zul_x_preferred":[
         "Dila"
     ],
     "ne:ADM0CAP":0.0,
@@ -295,7 +308,7 @@
         }
     ],
     "wof:id":421197339,
-    "wof:lastmodified":1636503447,
+    "wof:lastmodified":1690879622,
     "wof:name":"Dila",
     "wof:parent_id":421204107,
     "wof:placetype":"locality",

--- a/data/421/197/341/421197341.geojson
+++ b/data/421/197/341/421197341.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u062f\u0645\u0628\u064a\u062f\u0648\u0644\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0645\u0628\u064a\u062f\u0648\u0644\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Dembi Dollo"
+    ],
     "name:ben_x_preferred":[
         "\u09a6\u09c7\u09ae\u09cd\u09ac\u09bf \u09a6\u09cb\u09b2\u09cb"
     ],
@@ -38,8 +44,14 @@
     "name:eng_x_variant":[
         "Dembi Dollo"
     ],
+    "name:fas_x_preferred":[
+        "\u062f\u0645\u0628\u06cc\u062f\u0648\u0644\u0648"
+    ],
     "name:fra_x_preferred":[
         "Dembidolo"
+    ],
+    "name:fra_x_variant":[
+        "Dembi Dolo"
     ],
     "name:hbs_x_preferred":[
         "Dembidolo"
@@ -98,6 +110,9 @@
     "name:tur_x_preferred":[
         "Dembi Dolo"
     ],
+    "name:ukr_x_preferred":[
+        "\u0414\u0435\u043c\u0431\u0456-\u0414\u043e\u043b\u043e"
+    ],
     "name:und_x_variant":[
         "Saio"
     ],
@@ -109,6 +124,9 @@
     ],
     "name:zho_x_preferred":[
         "\u767b\u6bd4\u591a\u6d1b"
+    ],
+    "name:zul_x_preferred":[
+        "Dembidolo"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -252,7 +270,7 @@
         }
     ],
     "wof:id":421197341,
-    "wof:lastmodified":1636503447,
+    "wof:lastmodified":1690879622,
     "wof:name":"Dembi Dolo",
     "wof:parent_id":1108695233,
     "wof:placetype":"locality",

--- a/data/421/198/509/421198509.geojson
+++ b/data/421/198/509/421198509.geojson
@@ -20,6 +20,9 @@
     "name:amh_x_preferred":[
         "\u1260\u12f0\u120c \u12a8\u1270\u121b"
     ],
+    "name:ast_x_preferred":[
+        "Bedele"
+    ],
     "name:ceb_x_preferred":[
         "Bedel\u0113"
     ],
@@ -32,11 +35,17 @@
     "name:nld_x_preferred":[
         "Bedele"
     ],
+    "name:pol_x_preferred":[
+        "Bedele"
+    ],
     "name:swe_x_preferred":[
         "Bedel\u0113"
     ],
     "name:und_x_variant":[
         "Beddele"
+    ],
+    "name:zul_x_preferred":[
+        "Bedele"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -86,7 +95,7 @@
         }
     ],
     "wof:id":421198509,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1690879620,
     "wof:name":"Bedele",
     "wof:parent_id":890446963,
     "wof:placetype":"locality",

--- a/data/421/198/511/421198511.geojson
+++ b/data/421/198/511/421198511.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Bichena"
+    ],
     "name:bul_x_preferred":[
         "\u0411\u0438\u0447\u0435\u043d\u0430"
     ],
@@ -32,6 +35,9 @@
     "name:nld_x_preferred":[
         "Bichena"
     ],
+    "name:pol_x_preferred":[
+        "Bichena"
+    ],
     "name:swe_x_preferred":[
         "Bichena"
     ],
@@ -40,6 +46,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6bd4\u5fb9\u7d0d"
+    ],
+    "name:zul_x_preferred":[
+        "Bichena"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -92,7 +101,7 @@
         }
     ],
     "wof:id":421198511,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1690879620,
     "wof:name":"Bichena",
     "wof:parent_id":1108695153,
     "wof:placetype":"locality",

--- a/data/421/198/513/421198513.geojson
+++ b/data/421/198/513/421198513.geojson
@@ -23,6 +23,9 @@
     "name:eng_x_preferred":[
         "Dubti"
     ],
+    "name:fin_x_preferred":[
+        "Dubti"
+    ],
     "name:nld_x_preferred":[
         "Dubti"
     ],
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":421198513,
-    "wof:lastmodified":1566593556,
+    "wof:lastmodified":1690879620,
     "wof:name":"Dubti",
     "wof:parent_id":1108695243,
     "wof:placetype":"locality",

--- a/data/421/200/119/421200119.geojson
+++ b/data/421/200/119/421200119.geojson
@@ -37,6 +37,12 @@
     "name:ara_x_preferred":[
         "\u063a\u0648\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u062f\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Gode"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09cb\u09a1\u09c7"
     ],
@@ -136,6 +142,9 @@
     "name:spa_x_preferred":[
         "Gode"
     ],
+    "name:swa_x_preferred":[
+        "Gode"
+    ],
     "name:swe_x_preferred":[
         "Gode"
     ],
@@ -162,6 +171,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6208\u5fb7"
+    ],
+    "name:zul_x_preferred":[
+        "Gode"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -228,7 +240,7 @@
         }
     ],
     "wof:id":421200119,
-    "wof:lastmodified":1636503447,
+    "wof:lastmodified":1690879623,
     "wof:name":"Gode",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/200/235/421200235.geojson
+++ b/data/421/200/235/421200235.geojson
@@ -53,6 +53,9 @@
     "name:und_x_variant":[
         "Addis Zaman"
     ],
+    "name:zul_x_preferred":[
+        "Addis Zemen"
+    ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":344923,
@@ -101,7 +104,7 @@
         }
     ],
     "wof:id":421200235,
-    "wof:lastmodified":1566593557,
+    "wof:lastmodified":1690879622,
     "wof:name":"Adis Zemen",
     "wof:parent_id":1108695205,
     "wof:placetype":"locality",

--- a/data/421/201/463/421201463.geojson
+++ b/data/421/201/463/421201463.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u0625\u0631\u063a\u0627\u0644\u0645"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0631\u062c\u0627\u0644\u0645"
+    ],
     "name:bar_x_preferred":[
         "Irgalem"
     ],
@@ -89,6 +92,9 @@
     "name:spa_x_preferred":[
         "Irgalem"
     ],
+    "name:swa_x_preferred":[
+        "Irgalem"
+    ],
     "name:swe_x_preferred":[
         "Yirga \u2018Alem"
     ],
@@ -112,6 +118,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u5409\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Irgalem"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -252,7 +261,7 @@
         }
     ],
     "wof:id":421201463,
-    "wof:lastmodified":1636503447,
+    "wof:lastmodified":1690879623,
     "wof:name":"Yirga Alem",
     "wof:parent_id":421204421,
     "wof:placetype":"locality",

--- a/data/421/201/473/421201473.geojson
+++ b/data/421/201/473/421201473.geojson
@@ -17,6 +17,9 @@
     "mz:is_current":1,
     "mz:min_zoom":10.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Yabelo"
+    ],
     "name:ceb_x_preferred":[
         "Yab\u0113lo"
     ],
@@ -30,6 +33,9 @@
         "Javello"
     ],
     "name:nld_x_preferred":[
+        "Yabelo"
+    ],
+    "name:pol_x_preferred":[
         "Yabelo"
     ],
     "name:ron_x_preferred":[
@@ -46,6 +52,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4e9e\u8c9d\u6d1b"
+    ],
+    "name:zul_x_preferred":[
+        "Yabelo"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -98,7 +107,7 @@
         }
     ],
     "wof:id":421201473,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1690879623,
     "wof:name":"Yabalo",
     "wof:parent_id":421188225,
     "wof:placetype":"locality",

--- a/data/421/201/965/421201965.geojson
+++ b/data/421/201/965/421201965.geojson
@@ -23,6 +23,15 @@
     "name:ara_x_preferred":[
         "\u062c\u064a\u062c\u064a\u062c\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u062c\u064a\u062c\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Jijiga"
+    ],
+    "name:bel_x_preferred":[
+        "\u0414\u0436\u044b\u0434\u0436\u044b\u0433\u0430"
+    ],
     "name:ben_x_preferred":[
         "\u099c\u09bf\u099c\u09bf\u0997\u09be"
     ],
@@ -56,11 +65,20 @@
     "name:eus_x_preferred":[
         "Jijiga"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u06cc\u062c\u06cc\u06af\u0627"
+    ],
     "name:fin_x_preferred":[
         "Jijiga"
     ],
     "name:fra_x_preferred":[
         "Djidjiga"
+    ],
+    "name:gle_x_preferred":[
+        "Jijiga"
+    ],
+    "name:glg_x_preferred":[
+        "Jijiga"
     ],
     "name:guj_x_preferred":[
         "\u0a9c\u0ac0\u0a9c\u0abf\u0a97\u0abe"
@@ -146,8 +164,14 @@
     "name:spa_x_preferred":[
         "Jijiga"
     ],
+    "name:swa_x_preferred":[
+        "Jijiga"
+    ],
     "name:swe_x_preferred":[
         "Jijiga"
+    ],
+    "name:szl_x_preferred":[
+        "D\u017cid\u017ciga"
     ],
     "name:tam_x_preferred":[
         "\u0b9c\u0bbf\u0b9c\u0bbf\u0b95\u0bbe"
@@ -170,11 +194,17 @@
     "name:urd_x_preferred":[
         "\u062c\u06cc\u062c\u06cc\u06af\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Giggiga"
+    ],
     "name:vie_x_preferred":[
         "Jijiga"
     ],
     "name:zho_x_preferred":[
         "\u5409\u5409\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Jijiga"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -320,7 +350,7 @@
         }
     ],
     "wof:id":421201965,
-    "wof:lastmodified":1566593558,
+    "wof:lastmodified":1690879623,
     "wof:name":"Jijiga",
     "wof:parent_id":421188343,
     "wof:placetype":"locality",

--- a/data/421/202/225/421202225.geojson
+++ b/data/421/202/225/421202225.geojson
@@ -29,8 +29,17 @@
     "name:arg_x_preferred":[
         "Lalibela"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u0627\u0644\u064a\u0628\u064a\u0644\u0627"
+    ],
     "name:ast_x_preferred":[
         "Lalibela"
+    ],
+    "name:aze_x_preferred":[
+        "Lalibela"
+    ],
+    "name:bak_x_preferred":[
+        "\u041b\u0430\u043b\u0438\u0431\u044d\u043b\u0430"
     ],
     "name:bel_x_preferred":[
         "\u041b\u0430\u043b\u0456\u0431\u044d\u043b\u0430"
@@ -92,6 +101,9 @@
     "name:hrv_x_preferred":[
         "Lalibela"
     ],
+    "name:hye_x_preferred":[
+        "\u053c\u0561\u056c\u056b\u0562\u0565\u056c\u0561"
+    ],
     "name:ind_x_preferred":[
         "Lalibela"
     ],
@@ -103,6 +115,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub784\ub9ac\ubca8\ub77c"
+    ],
+    "name:lat_x_preferred":[
+        "Lalibela"
     ],
     "name:lit_x_preferred":[
         "Lalibela"
@@ -120,6 +135,9 @@
         "Lalibela"
     ],
     "name:nor_x_preferred":[
+        "Lalibela"
+    ],
+    "name:oci_x_preferred":[
         "Lalibela"
     ],
     "name:pol_x_preferred":[
@@ -152,6 +170,9 @@
     "name:swe_x_preferred":[
         "Lalibela"
     ],
+    "name:tha_x_preferred":[
+        "\u0e25\u0e32\u0e25\u0e35\u0e40\u0e1a\u0e25\u0e32"
+    ],
     "name:ukr_x_preferred":[
         "\u041b\u0430\u043b\u0456\u0431\u0435\u043b\u0430"
     ],
@@ -167,8 +188,14 @@
     "name:war_x_preferred":[
         "Lalibela"
     ],
+    "name:yue_x_preferred":[
+        "\u62c9\u5229\u8c9d\u62c9"
+    ],
     "name:zho_x_preferred":[
         "\u62c9\u5229\u8c9d\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Lalibela"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -221,7 +248,7 @@
         }
     ],
     "wof:id":421202225,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879617,
     "wof:name":"Lalibela",
     "wof:parent_id":1108695201,
     "wof:placetype":"locality",

--- a/data/421/203/041/421203041.geojson
+++ b/data/421/203/041/421203041.geojson
@@ -17,17 +17,29 @@
     "mz:is_current":1,
     "mz:min_zoom":9.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ast_x_preferred":[
+        "Batu"
+    ],
     "name:ceb_x_preferred":[
         "Ziway"
     ],
+    "name:deu_x_preferred":[
+        "Batu"
+    ],
     "name:eng_x_preferred":[
         "Ziway"
+    ],
+    "name:eng_x_variant":[
+        "Batu"
     ],
     "name:fra_x_preferred":[
         "Ziway"
     ],
     "name:hbs_x_preferred":[
         "Zivaj"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d1\u05d0\u05d8\u05d5"
     ],
     "name:hrv_x_preferred":[
         "Zivaj"
@@ -40,6 +52,9 @@
     ],
     "name:nld_x_preferred":[
         "Ziway"
+    ],
+    "name:orm_x_preferred":[
+        "Baatuu"
     ],
     "name:pol_x_preferred":[
         "Ziway"
@@ -58,6 +73,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8332\u61f7"
+    ],
+    "name:zul_x_preferred":[
+        "Ziway"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -110,7 +128,7 @@
         }
     ],
     "wof:id":421203041,
-    "wof:lastmodified":1566593553,
+    "wof:lastmodified":1690879617,
     "wof:name":"Ziway",
     "wof:parent_id":1108695157,
     "wof:placetype":"locality",

--- a/data/421/203/043/421203043.geojson
+++ b/data/421/203/043/421203043.geojson
@@ -20,7 +20,13 @@
     "name:ara_x_preferred":[
         "\u0643\u0648\u0646\u0633\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0648\u0646\u0633\u0648"
+    ],
     "name:ast_x_preferred":[
+        "Konso"
+    ],
+    "name:aze_x_preferred":[
         "Konso"
     ],
     "name:cat_x_preferred":[
@@ -31,6 +37,9 @@
     ],
     "name:dan_x_preferred":[
         "Konsos kulturlandskab"
+    ],
+    "name:dan_x_variant":[
+        "Konso"
     ],
     "name:deu_x_preferred":[
         "Konso"
@@ -44,11 +53,20 @@
     "name:fin_x_preferred":[
         "Konson kulttuurimaisema"
     ],
+    "name:fin_x_variant":[
+        "Konso"
+    ],
     "name:fra_x_preferred":[
         "Konso"
     ],
     "name:heb_x_preferred":[
         "\u05d4\u05e0\u05d5\u05e3 \u05d4\u05ea\u05e8\u05d1\u05d5\u05ea\u05d9 \u05e9\u05dc \u05e7\u05d5\u05e0\u05e1\u05d5"
+    ],
+    "name:hrv_x_preferred":[
+        "Konso"
+    ],
+    "name:hye_x_preferred":[
+        "\u053f\u0578\u0576\u057d\u0578"
     ],
     "name:ita_x_preferred":[
         "Konso"
@@ -59,11 +77,17 @@
     "name:kat_x_preferred":[
         "\u10d9\u10dd\u10dc\u10e1\u10dd"
     ],
+    "name:lit_x_preferred":[
+        "Konsas"
+    ],
     "name:nld_x_preferred":[
         "Konso"
     ],
     "name:nob_x_preferred":[
         "Konsos kulturlandskap"
+    ],
+    "name:nob_x_variant":[
+        "Konso"
     ],
     "name:nor_x_preferred":[
         "Konsos kulturlandskap"
@@ -86,6 +110,9 @@
     "name:swe_x_preferred":[
         "Karat"
     ],
+    "name:swe_x_variant":[
+        "Konso"
+    ],
     "name:tur_x_preferred":[
         "Konso"
     ],
@@ -94,6 +121,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5b54\u7d22"
+    ],
+    "name:zul_x_preferred":[
+        "Konso"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -143,7 +173,7 @@
         }
     ],
     "wof:id":421203043,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879617,
     "wof:name":"Konso",
     "wof:parent_id":1108695183,
     "wof:placetype":"locality",

--- a/data/421/203/045/421203045.geojson
+++ b/data/421/203/045/421203045.geojson
@@ -20,6 +20,9 @@
     "name:bul_x_preferred":[
         "\u0410\u0441\u0430\u0438\u0442\u0430"
     ],
+    "name:cat_x_preferred":[
+        "Asayita"
+    ],
     "name:ceb_x_preferred":[
         "Asaita"
     ],
@@ -27,6 +30,12 @@
         "Asaita"
     ],
     "name:eng_x_preferred":[
+        "Asaita"
+    ],
+    "name:epo_x_preferred":[
+        "Asaita"
+    ],
+    "name:fin_x_preferred":[
         "Asaita"
     ],
     "name:fra_x_preferred":[
@@ -62,8 +71,17 @@
     "name:swe_x_preferred":[
         "Asaita"
     ],
+    "name:ukr_x_preferred":[
+        "\u0410\u0441\u0430\u0457\u0442\u0430"
+    ],
     "name:und_x_variant":[
         "Aisaita"
+    ],
+    "name:zho_x_preferred":[
+        "\u963f\u8428\u4f0a\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Asaita"
     ],
     "qs:gn_country":"ET",
     "qs:gn_fcode":"PPL",
@@ -113,7 +131,7 @@
         }
     ],
     "wof:id":421203045,
-    "wof:lastmodified":1566593554,
+    "wof:lastmodified":1690879617,
     "wof:name":"Asayita",
     "wof:parent_id":1108695243,
     "wof:placetype":"locality",

--- a/data/421/203/047/421203047.geojson
+++ b/data/421/203/047/421203047.geojson
@@ -17,8 +17,14 @@
     "mz:is_current":1,
     "mz:min_zoom":12.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0647\u0648\u0632\u0646"
+    ],
     "name:ceb_x_preferred":[
         "Hawz\u0113n"
+    ],
+    "name:deu_x_preferred":[
+        "Hawzen"
     ],
     "name:eng_x_preferred":[
         "Hawzen"
@@ -26,7 +32,13 @@
     "name:fra_x_preferred":[
         "Hawzen"
     ],
+    "name:heb_x_preferred":[
+        "\u05d7\u05d5\u05d5\u05d6\u05d9\u05d0\u05df"
+    ],
     "name:nld_x_preferred":[
+        "Hawzen"
+    ],
+    "name:spa_x_preferred":[
         "Hawzen"
     ],
     "name:swe_x_preferred":[
@@ -82,7 +94,7 @@
         }
     ],
     "wof:id":421203047,
-    "wof:lastmodified":1566593553,
+    "wof:lastmodified":1690879617,
     "wof:name":"Hawzen",
     "wof:parent_id":1108695161,
     "wof:placetype":"locality",

--- a/data/421/204/107/421204107.geojson
+++ b/data/421/204/107/421204107.geojson
@@ -53,17 +53,29 @@
     "name:fra_x_preferred":[
         "Gedeo"
     ],
+    "name:ita_x_preferred":[
+        "Gedeo"
+    ],
     "name:jpn_x_preferred":[
         "\u30b2\u30c7\u30aa\u770c"
     ],
     "name:pol_x_preferred":[
         "Strefa Gedeo"
     ],
+    "name:rus_x_preferred":[
+        "\u0413\u0435\u0434\u0435\u043e"
+    ],
     "name:swe_x_preferred":[
         "Gedeo Zone"
     ],
+    "name:swe_x_variant":[
+        "Gedeo"
+    ],
     "name:zho_x_preferred":[
         "\u84cb\u5fb7\u5967\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Gedeo Zone"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -128,7 +140,7 @@
         }
     ],
     "wof:id":421204107,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879616,
     "wof:name":"Gedeo",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/421/204/421/421204421.geojson
+++ b/data/421/204/421/421204421.geojson
@@ -34,32 +34,87 @@
     "mz:is_current":1,
     "mz:min_zoom":6.0,
     "mz:note":"quattroshapes points import (201603)",
+    "name:ara_x_preferred":[
+        "\u0648\u0644\u0627\u064a\u0629 \u0633\u064a\u062f\u0627\u0645\u0627"
+    ],
+    "name:cat_x_preferred":[
+        "Sidama"
+    ],
     "name:ceb_x_preferred":[
         "Sidama Zone"
     ],
+    "name:ces_x_preferred":[
+        "Sidama"
+    ],
     "name:deu_x_preferred":[
         "Sidama-Zone"
+    ],
+    "name:deu_x_variant":[
+        "Sidama"
     ],
     "name:eng_x_preferred":[
         "Sidama"
     ],
     "name:eng_x_variant":[
-        "Sidama Zone"
+        "Sidama Zone",
+        "Sidama Region"
+    ],
+    "name:fas_x_preferred":[
+        "\u0646\u0627\u062d\u06cc\u0647 \u0633\u06cc\u062f\u0627\u0645\u0627"
     ],
     "name:fra_x_preferred":[
         "Sidama"
     ],
+    "name:heb_x_preferred":[
+        "\u05e1\u05d9\u05d3\u05de\u05d0\u05d4"
+    ],
+    "name:hun_x_preferred":[
+        "Szidama"
+    ],
     "name:jpn_x_preferred":[
         "\u30b7\u30c0\u30de\u770c"
+    ],
+    "name:kor_x_preferred":[
+        "\uc2dc\ub2e4\ub9c8\uc8fc"
+    ],
+    "name:nob_x_preferred":[
+        "Sidama"
+    ],
+    "name:oci_x_preferred":[
+        "Sidama"
+    ],
+    "name:orm_x_preferred":[
+        "Naannoo Sidaamaa"
     ],
     "name:pol_x_preferred":[
         "Strefa Sidama"
     ],
+    "name:por_x_preferred":[
+        "Sidama"
+    ],
+    "name:ron_x_preferred":[
+        "Statul Sidama"
+    ],
+    "name:rus_x_preferred":[
+        "\u0421\u0438\u0434\u0430\u043c\u0430"
+    ],
     "name:swe_x_preferred":[
         "Sidama Zone"
     ],
+    "name:swe_x_variant":[
+        "Sidama"
+    ],
+    "name:tam_x_preferred":[
+        "\u0b9a\u0bbf\u0ba4\u0bbe\u0bae\u0bbe \u0baa\u0bbf\u0bb0\u0ba4\u0bc7\u0b9a\u0bae\u0bcd"
+    ],
+    "name:vie_x_preferred":[
+        "Sidama"
+    ],
     "name:zho_x_preferred":[
         "\u932b\u9054\u99ac\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Sidama Region"
     ],
     "qs:gn_country":null,
     "qs:gn_fcode":null,
@@ -123,7 +178,7 @@
         }
     ],
     "wof:id":421204421,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879616,
     "wof:name":"Sidama",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/856/322/57/85632257.geojson
+++ b/data/856/322/57/85632257.geojson
@@ -31,6 +31,9 @@
     "name:aar_x_preferred":[
         "Otobbia"
     ],
+    "name:abk_x_preferred":[
+        "\u0415\u0444\u0438\u043e\u043f\u0438\u0430"
+    ],
     "name:ace_x_preferred":[
         "Ethiopia"
     ],
@@ -43,6 +46,9 @@
     "name:aka_x_preferred":[
         "Ithiopia"
     ],
+    "name:aka_x_variant":[
+        "Ethiopia"
+    ],
     "name:als_x_preferred":[
         "\u00c4thiopien"
     ],
@@ -54,8 +60,14 @@
         "Ye\u012atyop\u2019iya Hizbaw\u012b D\u012bmokras\u012byaw\u012b R\u012bpubl\u012bk",
         "\u012atyop\u2019iya"
     ],
+    "name:ami_x_preferred":[
+        "Ethiopia"
+    ],
     "name:ang_x_preferred":[
         "Sigelhearwenaland"
+    ],
+    "name:anp_x_preferred":[
+        "\u0907\u0925\u093f\u092f\u094b\u092a\u093f\u092f\u093e"
     ],
     "name:ara_x_preferred":[
         "\u0625\u062b\u064a\u0648\u0628\u064a\u0627"
@@ -80,6 +92,9 @@
     ],
     "name:ava_x_preferred":[
         "\u0425\u0430\u0431\u0430\u0448\u0438\u0441\u0442\u0430\u043d"
+    ],
+    "name:avk_x_preferred":[
+        "Ityopia"
     ],
     "name:aym_x_preferred":[
         "Itiwpiya"
@@ -122,6 +137,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0907\u0925\u093f\u092f\u094b\u092a\u093f\u092f\u093e"
+    ],
+    "name:bis_x_preferred":[
+        "Itiopia"
     ],
     "name:bjn_x_preferred":[
         "Ethiopia"
@@ -193,6 +211,9 @@
         "Etiopi\u00f4"
     ],
     "name:cym_x_preferred":[
+        "Ethiopia"
+    ],
+    "name:dag_x_preferred":[
         "Ethiopia"
     ],
     "name:dan_x_preferred":[
@@ -332,6 +353,9 @@
     "name:gom_x_preferred":[
         "\u0907\u0925\u093f\u0913\u092a\u093f\u092f\u093e"
     ],
+    "name:gpe_x_preferred":[
+        "Ethiopia"
+    ],
     "name:grn_x_preferred":[
         "Etiop\u00eda"
     ],
@@ -346,6 +370,9 @@
     ],
     "name:guj_x_variant":[
         "\u0a87\u0aa5\u0abf\u0a93\u0aaa\u0abf\u0aaf\u0abe"
+    ],
+    "name:gur_x_preferred":[
+        "Ethiopia"
     ],
     "name:hak_x_preferred":[
         "Ethiopia"
@@ -428,6 +455,9 @@
     "name:jav_x_preferred":[
         "\u00c9tiopia"
     ],
+    "name:jav_x_variant":[
+        "\u00c9teopiah"
+    ],
     "name:jbo_x_preferred":[
         "itiopias"
     ],
@@ -463,6 +493,9 @@
     ],
     "name:kbp_x_preferred":[
         "Etiyoopii"
+    ],
+    "name:kcg_x_preferred":[
+        "Ityopya"
     ],
     "name:khm_x_preferred":[
         "\u17a2\u17c1\u178f\u17d2\u1799\u17bc\u1796\u17b8"
@@ -534,6 +567,9 @@
     "name:lit_x_preferred":[
         "Etiopija"
     ],
+    "name:lld_x_preferred":[
+        "Etiopia"
+    ],
     "name:lmo_x_preferred":[
         "Etiopia"
     ],
@@ -558,6 +594,9 @@
     "name:lzh_x_preferred":[
         "\u8863\u7d22\u6bd4\u4e9e"
     ],
+    "name:mad_x_preferred":[
+        "Ethiopia"
+    ],
     "name:mai_x_preferred":[
         "\u0907\u0925\u093f\u092f\u094b\u092a\u093f\u092f\u093e"
     ],
@@ -569,6 +608,9 @@
     ],
     "name:mar_x_variant":[
         "\u0907\u0925\u093f\u0913\u092a\u093f\u092f\u093e"
+    ],
+    "name:mdf_x_preferred":[
+        "\u042d\u0442\u0438\u043e\u043f\u0438\u044f"
     ],
     "name:mhr_x_preferred":[
         "\u042d\u0444\u0438\u043e\u043f\u0438\u0439"
@@ -590,6 +632,9 @@
     ],
     "name:mlt_x_variant":[
         "Etijopja"
+    ],
+    "name:mni_x_preferred":[
+        "\uabd1\uabe6\uabca\uabe4\uabcc\uabe3\uabc4\uabe4\uabcc\uabe5"
     ],
     "name:mon_x_preferred":[
         "\u042d\u0442\u0438\u043e\u043f"
@@ -663,6 +708,9 @@
     "name:nov_x_preferred":[
         "Etiopia"
     ],
+    "name:nqo_x_preferred":[
+        "\u07cb\u07d7\u07cf\u07d4\u07cc\u07eb"
+    ],
     "name:nso_x_preferred":[
         "Ethiopia"
     ],
@@ -717,6 +765,9 @@
     "name:pus_x_variant":[
         "\u062d\u0628\u0634\u0647"
     ],
+    "name:pwn_x_preferred":[
+        "Isubya"
+    ],
     "name:que_x_preferred":[
         "Ithiyupya"
     ],
@@ -759,6 +810,9 @@
     "name:sgs_x_preferred":[
         "Etiuop\u0117j\u0117"
     ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u1022\u102e\u1087\u1010\u102e\u1087\u101a\u1030\u101d\u103a\u1038\u1015\u102e\u1038\u101a\u1083\u1038"
+    ],
     "name:sin_x_preferred":[
         "\u0d89\u0dad\u0dd2\u0dba\u0ddd\u0db4\u0dd2\u0dba\u0dcf\u0dc0"
     ],
@@ -771,11 +825,20 @@
     "name:sme_x_preferred":[
         "Etiopia"
     ],
+    "name:smj_x_preferred":[
+        "Eti\u00e5vpp\u00e5"
+    ],
+    "name:smn_x_preferred":[
+        "Etiopia"
+    ],
     "name:smo_x_preferred":[
         "Aitiope"
     ],
     "name:smo_x_variant":[
         "Ethiopia"
+    ],
+    "name:sms_x_preferred":[
+        "Etiopia"
     ],
     "name:sna_x_preferred":[
         "Ethiopia"
@@ -870,8 +933,14 @@
     "name:tir_x_preferred":[
         "\u12a2\u1275\u12ee\u1335\u12eb"
     ],
+    "name:tok_x_preferred":[
+        "ma Isijopija"
+    ],
     "name:ton_x_preferred":[
         "\u02bbIti\u014dpea"
+    ],
+    "name:trv_x_preferred":[
+        "Ethiopia"
     ],
     "name:tso_x_preferred":[
         "Topiya"
@@ -879,8 +948,14 @@
     "name:tuk_x_preferred":[
         "Efiopi\u00fda"
     ],
+    "name:tum_x_preferred":[
+        "Ethiopia"
+    ],
     "name:tur_x_preferred":[
         "Etiyopya"
+    ],
+    "name:twi_x_preferred":[
+        "Ethiopia"
     ],
     "name:udm_x_preferred":[
         "\u042d\u0444\u0438\u043e\u043f\u0438\u044f"
@@ -904,6 +979,9 @@
     "name:vec_x_preferred":[
         "Etiopia"
     ],
+    "name:vec_x_variant":[
+        "Eti\u00f2pia"
+    ],
     "name:vep_x_preferred":[
         "Efiopii"
     ],
@@ -913,6 +991,9 @@
     "name:vie_x_variant":[
         "\u00ca-ti-\u00f4-pi-a",
         "\u00ca-ti-\u00f4-pi-a (Ethiopia)"
+    ],
+    "name:vls_x_preferred":[
+        "Ethiopi\u00eb"
     ],
     "name:vol_x_preferred":[
         "L\u00e4tiop\u00e4n"
@@ -1195,7 +1276,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1617827634,
+    "wof:lastmodified":1690879600,
     "wof:name":"Ethiopia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/711/21/85671121.geojson
+++ b/data/856/711/21/85671121.geojson
@@ -42,6 +42,9 @@
     "name:ara_x_variant":[
         "\u0648\u0644\u0627\u064a\u0629 \u0623\u0645\u0647\u0631\u0629"
     ],
+    "name:ast_x_preferred":[
+        "Rex\u00f3n d'Amhara"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09ae\u09b9\u09be\u09b0\u09be \u0985\u099e\u09cd\u099a\u09b2"
     ],
@@ -80,6 +83,9 @@
     "name:epo_x_preferred":[
         "Regiono Amharo"
     ],
+    "name:est_x_preferred":[
+        "Amhara osariik"
+    ],
     "name:eus_x_preferred":[
         "Amhara eskualdea"
     ],
@@ -91,6 +97,9 @@
     ],
     "name:fra_x_preferred":[
         "Amhara"
+    ],
+    "name:frr_x_preferred":[
+        "Amhaara"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0aae\u0ab9\u0abe\u0ab0\u0abe \u0aaa\u0acd\u0ab0\u0aa6\u0ac7\u0ab6"
@@ -194,6 +203,9 @@
     "name:tam_x_preferred":[
         "\u0b85\u0bae\u0bcd\u0bae\u0bb0 \u0baa\u0b95\u0bc1\u0ba4\u0bbf"
     ],
+    "name:tam_x_variant":[
+        "\u0b85\u0bae\u0bcd\u0bae\u0bbe\u0bb0\u0baa\u0bcd \u0baa\u0b95\u0bc1\u0ba4\u0bbf"
+    ],
     "name:tat_x_preferred":[
         "\u0410\u043c\u0445\u0430\u0440\u0430 \u0442\u04e9\u0431\u04d9\u0433\u0435"
     ],
@@ -226,6 +238,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u59c6\u54c8\u62c9\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Amhara Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -350,7 +365,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1690879602,
     "wof:name":"Amhara",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/25/85671125.geojson
+++ b/data/856/711/25/85671125.geojson
@@ -41,6 +41,15 @@
     "name:ara_x_preferred":[
         "\u062a\u064a\u063a\u0631\u0627\u064a"
     ],
+    "name:ara_x_variant":[
+        "\u062a\u063a\u0631\u0627\u064a"
+    ],
+    "name:arz_x_preferred":[
+        "\u062a\u064a\u062c\u0631\u0627\u0649"
+    ],
+    "name:bel_x_preferred":[
+        "\u0422\u044b\u0433\u0440\u0430\u0439"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09bf\u0997\u09cd\u09b0\u09c7 \u0985\u099e\u09cd\u099a\u09b2"
     ],
@@ -52,6 +61,9 @@
     ],
     "name:cat_x_preferred":[
         "Regi\u00f3 Tigr\u00e9"
+    ],
+    "name:cat_x_variant":[
+        "Tigre"
     ],
     "name:ces_x_preferred":[
         "Tigraj"
@@ -80,6 +92,9 @@
     "name:epo_x_preferred":[
         "Regiono Tigrajo"
     ],
+    "name:est_x_preferred":[
+        "Tigray osariik"
+    ],
     "name:eus_x_preferred":[
         "Tigray"
     ],
@@ -91,6 +106,9 @@
     ],
     "name:fra_x_preferred":[
         "Tigray"
+    ],
+    "name:fra_x_variant":[
+        "Tigr\u00e9"
     ],
     "name:guj_x_preferred":[
         "\u0a9f\u0abe\u0aaf\u0a97\u0acd\u0ab0\u0ac7 \u0aaa\u0acd\u0ab0\u0aa6\u0ac7\u0ab6"
@@ -107,6 +125,9 @@
     "name:hun_x_preferred":[
         "Tigr\u00e9"
     ],
+    "name:hye_x_preferred":[
+        "\u054f\u056b\u0563\u0580\u0561\u0575"
+    ],
     "name:ind_x_preferred":[
         "Region Tigray"
     ],
@@ -122,8 +143,14 @@
     "name:kat_x_preferred":[
         "\u10e2\u10d8\u10d2\u10e0\u10d0\u10d8\u10e1 \u10e0\u10d4\u10d2\u10d8\u10dd\u10dc\u10d8"
     ],
+    "name:kir_x_preferred":[
+        "\u0422\u044b\u0433\u0440\u0430\u0439"
+    ],
     "name:kor_x_preferred":[
         "\ud2f0\uadf8\ub808 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ud2f0\uadf8\ub77c\uc774\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Tigrajas kiliks"
@@ -136,6 +163,9 @@
     ],
     "name:msa_x_preferred":[
         "Tigray Region"
+    ],
+    "name:nep_x_preferred":[
+        "\u091f\u093f\u0917\u094d\u0930\u0947 \u0915\u094d\u0937\u0947\u0924\u094d\u0930"
     ],
     "name:nld_x_preferred":[
         "Tigray"
@@ -188,6 +218,9 @@
     "name:tha_x_preferred":[
         "\u0e44\u0e23\u0e40\u0e01\u0e23 \u0e23\u0e35\u0e40\u0e08\u0e35\u0e49\u0e22\u0e19"
     ],
+    "name:tir_x_preferred":[
+        "\u1275\u130d\u122b\u12ed"
+    ],
     "name:tur_x_preferred":[
         "Tigray B\u00f6lgesi"
     ],
@@ -203,11 +236,17 @@
     "name:vie_x_preferred":[
         "Tigray"
     ],
+    "name:war_x_preferred":[
+        "Tigray"
+    ],
     "name:wuu_x_preferred":[
         "\u63d0\u683c\u96f7\u5dde"
     ],
     "name:zho_x_preferred":[
         "\u63d0\u683c\u91cc\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Tigray Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -332,7 +371,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362116,
+    "wof:lastmodified":1690879604,
     "wof:name":"Tigray",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/29/85671129.geojson
+++ b/data/856/711/29/85671129.geojson
@@ -66,6 +66,9 @@
     "name:deu_x_preferred":[
         "Afar"
     ],
+    "name:deu_x_variant":[
+        "Afar-Region"
+    ],
     "name:ell_x_preferred":[
         "\u0391\u03c6\u03ac\u03c1"
     ],
@@ -93,6 +96,9 @@
     "name:fra_x_preferred":[
         "Afar"
     ],
+    "name:frr_x_preferred":[
+        "Afar"
+    ],
     "name:guj_x_preferred":[
         "\u0a85\u0aab\u0abe\u0ab0 \u0aaa\u0acd\u0ab0\u0aa6\u0ac7\u0ab6"
     ],
@@ -107,6 +113,9 @@
     ],
     "name:hun_x_preferred":[
         "Afar"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0586\u0561\u0580"
     ],
     "name:ind_x_preferred":[
         "Region Afar"
@@ -137,6 +146,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0905\u092b\u093e\u0930 \u092a\u094d\u0930\u0926\u0947\u0936"
+    ],
+    "name:mkd_x_preferred":[
+        "\u0410\u0444\u0430\u0440"
     ],
     "name:msa_x_preferred":[
         "Afar Region"
@@ -174,6 +186,9 @@
     "name:spa_x_preferred":[
         "Afar"
     ],
+    "name:spa_x_variant":[
+        "Regi\u00f3n Afar"
+    ],
     "name:srp_x_preferred":[
         "\u0410\u0444\u0430\u0440"
     ],
@@ -209,6 +224,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u6cd5\u5c14\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Afar Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -333,7 +351,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1690879602,
     "wof:name":"Afar",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/33/85671133.geojson
+++ b/data/856/711/33/85671133.geojson
@@ -130,6 +130,9 @@
     "name:ind_x_preferred":[
         "Region Southern Nations"
     ],
+    "name:ind_x_variant":[
+        "Region Bangsa Selatan"
+    ],
     "name:ita_x_preferred":[
         "Regione delle Nazioni"
     ],
@@ -216,6 +219,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e0b\u0e32\u0e23\u0e4c\u0e40\u0e17\u0e34\u0e19 \u0e40\u0e19\u0e0a\u0e31\u0e48\u0e19"
+    ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e20\u0e39\u0e21\u0e34\u0e20\u0e32\u0e04\u0e02\u0e2d\u0e07\u0e1b\u0e23\u0e30\u0e0a\u0e32\u0e0a\u0e32\u0e15\u0e34 \u0e0a\u0e19\u0e0a\u0e32\u0e15\u0e34 \u0e41\u0e25\u0e30\u0e1b\u0e23\u0e30\u0e0a\u0e32\u0e0a\u0e19\u0e17\u0e32\u0e07\u0e43\u0e15\u0e49"
     ],
     "name:tur_x_preferred":[
         "G\u00fcney Uluslar\u0131 ve Halklar\u0131 B\u00f6lgesi"
@@ -362,7 +368,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1690879601,
     "wof:name":"Southern Nations, Nationalities and Peoples",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/37/85671137.geojson
+++ b/data/856/711/37/85671137.geojson
@@ -38,6 +38,9 @@
     "name:ara_x_preferred":[
         "\u062c\u0627\u0645\u0628\u064a\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0645\u0628\u0644\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09be\u09ae\u09cd\u09ac\u09c7\u09b2\u09be \u09aa\u09cd\u09b0\u09a6\u09c7\u09b6"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:hun_x_preferred":[
         "Gambela"
+    ],
+    "name:hye_x_preferred":[
+        "\u0533\u0561\u0574\u0562\u0565\u056c\u0561\u0575\u056b \u0574\u0561\u0580\u0566"
     ],
     "name:ind_x_preferred":[
         "Region Gambela"
@@ -203,8 +209,14 @@
     "name:vie_x_preferred":[
         "Gambela"
     ],
+    "name:wuu_x_preferred":[
+        "\u7518\u8d1d\u62c9\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u7518\u8c9d\u62c9\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Gambela Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -327,7 +339,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1690879602,
     "wof:name":"Gambella Peoples",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/41/85671141.geojson
+++ b/data/856/711/41/85671141.geojson
@@ -39,6 +39,9 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0631\u0648\u0645\u064a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0631\u0648\u0645\u064a\u0627"
+    ],
     "name:bel_x_preferred":[
         "\u0410\u0440\u043e\u043c\u0456\u044f"
     ],
@@ -59,6 +62,9 @@
     ],
     "name:ces_x_preferred":[
         "Oromie"
+    ],
+    "name:ckb_x_preferred":[
+        "\u0646\u0627\u0648\u0686\u06d5\u06cc \u0626\u06c6\u0631\u06c6\u0645\u06cc\u0627"
     ],
     "name:dan_x_preferred":[
         "Oromia Region"
@@ -107,6 +113,9 @@
     ],
     "name:hun_x_preferred":[
         "Oromia"
+    ],
+    "name:hye_x_preferred":[
+        "\u0555\u0580\u0578\u0574\u056b\u0561"
     ],
     "name:ind_x_preferred":[
         "Region Oromia"
@@ -165,6 +174,9 @@
     "name:por_x_preferred":[
         "Oromia"
     ],
+    "name:ron_x_preferred":[
+        "Statul Oromia"
+    ],
     "name:rus_x_preferred":[
         "\u041e\u0440\u043e\u043c\u0438\u044f"
     ],
@@ -189,8 +201,14 @@
     "name:tel_x_preferred":[
         "\u0c13\u0c30\u0c4b\u0c2e\u0c3f\u0c2f\u0c3e \u0c2a\u0c4d\u0c30\u0c3e\u0c02\u0c24\u0c02"
     ],
+    "name:tgk_x_preferred":[
+        "\u0432\u0438\u043b\u043e\u044f\u0442\u0438 \u041e\u0440\u043e\u043c\u0438\u044f"
+    ],
     "name:tha_x_preferred":[
         "\u0e08\u0e31\u0e07\u0e2b\u0e27\u0e31\u0e14\u0e0b\u0e32\u0e19 \u0e04\u0e23\u0e34\u0e2a\u0e42\u0e15\u0e1a\u0e32\u0e25"
+    ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e20\u0e39\u0e21\u0e34\u0e20\u0e32\u0e04\u0e2d\u0e2d\u0e23\u0e2d\u0e21\u0e34\u0e22\u0e32"
     ],
     "name:tur_x_preferred":[
         "Oromia B\u00f6lgesi"
@@ -210,8 +228,14 @@
     "name:vie_x_preferred":[
         "Oromia"
     ],
+    "name:wuu_x_preferred":[
+        "\u5965\u7f57\u7c73\u4e9a\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u5967\u7f85\u7c73\u4e9e\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Oromia Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -335,7 +359,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1690879603,
     "wof:name":"Oromiya",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/47/85671147.geojson
+++ b/data/856/711/47/85671147.geojson
@@ -40,6 +40,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0646\u064a\u0634\u0646\u0642\u0648\u0644-\u0642\u0645\u0627\u0632"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0646\u064a\u0634\u0646\u0642\u0648\u0644-\u0642\u0645\u0627\u0632"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09c7\u09a8\u09b8\u09bf\u0982\u0997\u09b2-\u0997\u09be\u09ae\u09c1\u099c \u0985\u099e\u09cd\u099a\u09b2"
     ],
@@ -82,6 +85,9 @@
     ],
     "name:epo_x_preferred":[
         "Beni\u015dangul-Gumazo"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u0646\u0637\u0642\u0647 \u0628\u0646\u06cc\u0634\u0627\u0646\u06af\u0648\u0644-\u06af\u0648\u0645\u0648\u0632"
     ],
     "name:fin_x_preferred":[
         "Benishangul-Gumuz"
@@ -212,6 +218,9 @@
     "name:vie_x_preferred":[
         "Benishangul-Gumuz"
     ],
+    "name:wuu_x_preferred":[
+        "\u672c\u5c1a\u53e4\u52d2-\u53e4\u9a6c\u5179\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u672c\u5c1a\u53e4\u52d2-\u53e4\u99ac\u8332\u5dde"
     ],
@@ -339,7 +348,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362116,
+    "wof:lastmodified":1690879604,
     "wof:name":"Beneshangul Gumuz",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/49/85671149.geojson
+++ b/data/856/711/49/85671149.geojson
@@ -36,6 +36,9 @@
     "name:afr_x_preferred":[
         "Addis Abeba"
     ],
+    "name:aka_x_preferred":[
+        "Addis-Abeba"
+    ],
     "name:amh_x_preferred":[
         "\u0100d\u012bs \u0100beba \u0100stedader"
     ],
@@ -49,11 +52,17 @@
     "name:arg_x_preferred":[
         "Addis Abeba"
     ],
+    "name:ary_x_preferred":[
+        "\u0623\u062f\u064a\u0633 \u0623\u0628\u0627\u0628\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u0627\u062f\u064a\u0633 \u0627\u0628\u0627\u0628\u0627"
     ],
     "name:ast_x_preferred":[
         "Ad\u00eds Abeba"
+    ],
+    "name:avk_x_preferred":[
+        "Addis Ababa"
     ],
     "name:azb_x_preferred":[
         "\u0622\u062f\u06cc\u0633\u200c\u0622\u0628\u0627\u0628\u0627"
@@ -63,6 +72,12 @@
     ],
     "name:bak_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:ban_x_preferred":[
+        "Addis Ababa"
+    ],
+    "name:bcl_x_preferred":[
+        "Addis Ababa"
     ],
     "name:bel_x_preferred":[
         "\u0410\u0434\u044b\u0441-\u0410\u0431\u0435\u0431\u0430"
@@ -95,6 +110,9 @@
         "Addis Abeba"
     ],
     "name:che_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:chv_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
     ],
     "name:ckb_x_preferred":[
@@ -144,6 +162,9 @@
         "\u0622\u062f\u06cc\u0633 \u0622\u0628\u0627\u0628\u0627"
     ],
     "name:fin_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:fit_x_preferred":[
         "Addis Abeba"
     ],
     "name:fra_x_preferred":[
@@ -197,6 +218,9 @@
     "name:hye_x_preferred":[
         "\u0531\u0564\u056b\u057d \u0531\u0562\u0565\u0562\u0561"
     ],
+    "name:hyw_x_preferred":[
+        "\u0531\u057f\u056b\u057d \u0531\u057a\u0565\u057a\u0561"
+    ],
     "name:ibo_x_preferred":[
         "Addis Ababa"
     ],
@@ -208,6 +232,9 @@
     ],
     "name:ina_x_preferred":[
         "Addis Ababa"
+    ],
+    "name:ina_x_variant":[
+        "Addis Abeba"
     ],
     "name:ind_x_preferred":[
         "Addis Ababa"
@@ -287,6 +314,12 @@
     "name:mar_x_preferred":[
         "\u0905\u0926\u093f\u0938 \u0905\u092c\u093e\u092c\u093e"
     ],
+    "name:mdf_x_preferred":[
+        "\u0410\u0434\u044b\u0441-\u0410\u0431\u044d\u0431\u0430"
+    ],
+    "name:mhr_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
     "name:mkd_x_preferred":[
         "\u0410\u0434\u0438\u0441 \u0410\u0431\u0435\u0431\u0430"
     ],
@@ -314,6 +347,9 @@
     "name:nan_x_preferred":[
         "Addis Abeba"
     ],
+    "name:nav_x_preferred":[
+        "T\u00f3 Sido H\u00e1\u00e1l\u012f\u0301"
+    ],
     "name:new_x_preferred":[
         "\u0905\u0926\u093f\u0938 \u0905\u092c\u093e\u092c\u093e"
     ],
@@ -329,11 +365,20 @@
     "name:nov_x_preferred":[
         "Adis Ababa"
     ],
+    "name:nqo_x_preferred":[
+        "\u07ca\u07d8\u07cc\u07db-\u07ca\u07d3\u07cb\u07d3\u07ca\u07eb"
+    ],
     "name:oci_x_preferred":[
         "Addis Abeba"
     ],
+    "name:olo_x_preferred":[
+        "Addis-Abeba"
+    ],
     "name:orm_x_preferred":[
         "Addis Abeba"
+    ],
+    "name:orm_x_variant":[
+        "Finfinne"
     ],
     "name:oss_x_preferred":[
         "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u00e6"
@@ -356,8 +401,14 @@
     "name:por_x_preferred":[
         "Adis Abeba"
     ],
+    "name:pus_x_preferred":[
+        "\u0622\u062f\u06cc\u0633 \u0622\u0628\u0627\u0628\u0627"
+    ],
     "name:que_x_preferred":[
         "Adis Ababa"
+    ],
+    "name:rmf_x_preferred":[
+        "Addis Abeba"
     ],
     "name:roh_x_preferred":[
         "Addis Abeba"
@@ -380,11 +431,38 @@
     "name:sin_x_preferred":[
         "\u0d85\u0da9\u0dd2\u0dc3\u0dca \u0d85\u0db6\u0dcf\u0db6\u0dcf"
     ],
+    "name:sjd_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
+    "name:sje_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:sju_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:skr_x_preferred":[
+        "\u0627\u062f\u06cc\u0633 \u0627\u0628\u0627\u0628\u0627"
+    ],
     "name:slk_x_preferred":[
         "Addis Abeba"
     ],
     "name:slv_x_preferred":[
         "Adis Abeba"
+    ],
+    "name:sma_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:sme_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:smj_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:smn_x_preferred":[
+        "Addis Abeba"
+    ],
+    "name:sms_x_preferred":[
+        "Addis Abeba"
     ],
     "name:sna_x_preferred":[
         "Addis Ababa"
@@ -419,6 +497,9 @@
     "name:tam_x_preferred":[
         "\u0b85\u0b9f\u0bbf\u0bb8\u0bcd \u0b85\u0baa\u0bbe\u0baa\u0bbe"
     ],
+    "name:tat_x_preferred":[
+        "\u0410\u0434\u0434\u0438\u0441-\u0410\u0431\u0435\u0431\u0430"
+    ],
     "name:tel_x_preferred":[
         "\u0c05\u0c26\u0c4d\u0c26\u0c3f\u0c38\u0c4d \u0c05\u0c2c\u0c3e\u0c2c\u0c3e"
     ],
@@ -430,6 +511,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e2d\u0e32\u0e14\u0e14\u0e34\u0e2a\u0e2d\u0e32\u0e1a\u0e32\u0e1a\u0e32"
+    ],
+    "name:tir_x_preferred":[
+        "\u12a3\u12f2\u1235 \u12a3\u1260\u1263"
     ],
     "name:tuk_x_preferred":[
         "Addis Ababa"
@@ -458,6 +542,9 @@
     "name:vie_x_preferred":[
         "Addis Ababa"
     ],
+    "name:vol_x_preferred":[
+        "Addis Ab\u00e4ba"
+    ],
     "name:vro_x_preferred":[
         "Addis Abeba"
     ],
@@ -484,6 +571,9 @@
     ],
     "name:zho_x_preferred":[
         "\u4e9a\u7684\u65af\u4e9a\u8d1d\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Addis Ababa"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -611,7 +701,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362116,
+    "wof:lastmodified":1690879604,
     "wof:name":"Addis Ababa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/55/85671155.geojson
+++ b/data/856/711/55/85671155.geojson
@@ -108,6 +108,9 @@
     "name:hun_x_preferred":[
         "Szom\u00e1lia"
     ],
+    "name:hye_x_preferred":[
+        "\u054d\u0578\u0574\u0561\u056c\u056b"
+    ],
     "name:ind_x_preferred":[
         "Region Somali"
     ],
@@ -122,6 +125,9 @@
     ],
     "name:kat_x_preferred":[
         "\u10e1\u10dd\u10db\u10d0\u10da\u10d8\u10e1 \u10e0\u10d4\u10d2\u10d8\u10dd\u10dc\u10d8"
+    ],
+    "name:kir_x_preferred":[
+        "\u0421\u043e\u043c\u0430\u043b\u0438"
     ],
     "name:kor_x_preferred":[
         "\uc18c\ub9d0\ub9ac \uc8fc"
@@ -149,6 +155,9 @@
     ],
     "name:nob_x_preferred":[
         "Somali"
+    ],
+    "name:orm_x_preferred":[
+        "Naannoo Sumaalee"
     ],
     "name:pnb_x_preferred":[
         "\u0635\u0648\u0628\u06c1 \u0633\u0648\u0645\u0627\u0644\u06cc"
@@ -207,8 +216,14 @@
     "name:vie_x_preferred":[
         "V\u00f9ng Somali"
     ],
+    "name:wuu_x_preferred":[
+        "\u7d22\u9a6c\u91cc\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u7d22\u99ac\u91cc\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Somali Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -333,7 +348,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1582362115,
+    "wof:lastmodified":1690879603,
     "wof:name":"Somali",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/59/85671159.geojson
+++ b/data/856/711/59/85671159.geojson
@@ -39,14 +39,26 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0631\u0629 \u062f\u0627\u0648\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0631\u0629 \u062f\u0627\u0648\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Dire Dawa"
+    ],
     "name:azb_x_preferred":[
         "\u062f\u06cc\u0631\u062f\u0627\u0648\u0647"
+    ],
+    "name:aze_x_preferred":[
+        "D\u0131re-Daua"
     ],
     "name:bel_x_preferred":[
         "\u0414\u044b\u0440\u044d-\u0414\u0430\u0443\u0430"
     ],
     "name:ben_x_preferred":[
         "\u09a1\u09be\u0987\u09b0\u09c7 \u09a1\u09be\u0993\u09af\u09bc"
+    ],
+    "name:bho_x_preferred":[
+        "\u0921\u093f\u0930\u0947 \u0921\u093e\u0935\u093e"
     ],
     "name:bre_x_preferred":[
         "Dire Dawa"
@@ -93,6 +105,12 @@
     "name:fra_x_preferred":[
         "Dire Dawa"
     ],
+    "name:gle_x_preferred":[
+        "Dire Dawa"
+    ],
+    "name:glg_x_preferred":[
+        "Dire Dawa"
+    ],
     "name:guj_x_preferred":[
         "\u0aa1\u0abf\u0ab0\u0ac7 \u0aa1\u0abe\u0ab5\u0abe"
     ],
@@ -110,6 +128,9 @@
     ],
     "name:hun_x_preferred":[
         "Dire Dawa"
+    ],
+    "name:hye_x_preferred":[
+        "\u0534\u056b\u0580\u0565 \u0534\u0561\u0578\u0582\u0561"
     ],
     "name:ind_x_preferred":[
         "Dire Dawa"
@@ -219,14 +240,23 @@
     "name:uzb_x_preferred":[
         "Diredava"
     ],
+    "name:vec_x_preferred":[
+        "Dire Daua"
+    ],
     "name:vie_x_preferred":[
         "Dire Dawa"
     ],
     "name:war_x_preferred":[
         "Dire Dawa"
     ],
+    "name:wuu_x_preferred":[
+        "\u5fb7\u96f7\u8fbe\u74e6"
+    ],
     "name:zho_x_preferred":[
         "\u5fb7\u96f7\u8fbe\u74e6"
+    ],
+    "name:zul_x_preferred":[
+        "Dire Dawa"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -354,7 +384,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1607993768,
+    "wof:lastmodified":1690879601,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/63/85671163.geojson
+++ b/data/856/711/63/85671163.geojson
@@ -112,6 +112,9 @@
     "name:hun_x_preferred":[
         "Harar"
     ],
+    "name:hye_x_preferred":[
+        "\u0540\u0561\u0580\u0561\u0580\u056b"
+    ],
     "name:ind_x_preferred":[
         "Region Harari"
     ],
@@ -157,6 +160,9 @@
     "name:nor_x_preferred":[
         "Harar"
     ],
+    "name:orm_x_preferred":[
+        "Naannoo Hararii"
+    ],
     "name:pnb_x_preferred":[
         "\u06c1\u0631\u0627\u0631\u06cc \u0635\u0648\u0628\u06c1"
     ],
@@ -168,6 +174,9 @@
     ],
     "name:ron_x_preferred":[
         "Statul Oromia"
+    ],
+    "name:ron_x_variant":[
+        "Statul Harari"
     ],
     "name:rus_x_preferred":[
         "\u0425\u0430\u0440\u0430\u0440\u0438"
@@ -196,6 +205,9 @@
     "name:tha_x_preferred":[
         "\u0e2e\u0e32\u0e23\u0e32\u0e23\u0e34"
     ],
+    "name:tha_x_variant":[
+        "\u0e23\u0e31\u0e10\u0e20\u0e39\u0e21\u0e34\u0e20\u0e32\u0e04\u0e2e\u0e32\u0e40\u0e23\u0e2d\u0e23\u0e4c"
+    ],
     "name:tur_x_preferred":[
         "Harari B\u00f6lgesi"
     ],
@@ -211,8 +223,14 @@
     "name:vie_x_preferred":[
         "Harari"
     ],
+    "name:wuu_x_preferred":[
+        "\u54c8\u52d2\u5c14\u5dde"
+    ],
     "name:zho_x_preferred":[
         "\u54c8\u52d2\u723e\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Harari Region"
     ],
     "ne:abbrev":"",
     "ne:adm0_a3":"ETH",
@@ -339,7 +357,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1607993758,
+    "wof:lastmodified":1690879603,
     "wof:name":"Harari People",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/890/418/071/890418071.geojson
+++ b/data/890/418/071/890418071.geojson
@@ -50,6 +50,12 @@
     "name:fra_x_preferred":[
         "Jimma"
     ],
+    "name:hye_x_preferred":[
+        "\u054b\u056b\u0574\u0574\u0561"
+    ],
+    "name:ita_x_preferred":[
+        "Jimma"
+    ],
     "name:jpn_x_preferred":[
         "\u30b8\u30f3\u30de\u770c"
     ],
@@ -62,11 +68,20 @@
     "name:swe_x_preferred":[
         "Jimma Zone"
     ],
+    "name:swe_x_variant":[
+        "Jima"
+    ],
+    "name:tgk_x_preferred":[
+        "\u043c\u0438\u043d\u0442\u0430\u049b\u0430\u0438 \u04b6\u0438\u043c\u043c\u0430"
+    ],
     "name:und_x_variant":[
         "J\u012bma \u0100wraja"
     ],
     "name:zho_x_preferred":[
         "\u5409\u99ac\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Jimma Zone"
     ],
     "qs:name":"Jimma Zone",
     "qs:photos_9r":0,
@@ -118,7 +133,7 @@
         }
     ],
     "wof:id":890418071,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879635,
     "wof:name":"Jimma",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/890/418/073/890418073.geojson
+++ b/data/890/418/073/890418073.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u0627\u0633\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u0627\u0633\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Hawaasa"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u0993\u09af\u09bc\u09be\u09b8\u09be"
     ],
@@ -46,11 +52,17 @@
     "name:deu_x_preferred":[
         "Awassa"
     ],
+    "name:deu_x_variant":[
+        "Awasa"
+    ],
     "name:ell_x_preferred":[
         "\u0391\u03bf\u03c5\u03ac\u03c3\u03b1"
     ],
     "name:eng_x_preferred":[
         "Awasa"
+    ],
+    "name:eng_x_variant":[
+        "Hawaasa"
     ],
     "name:epo_x_preferred":[
         "A\u016dasa"
@@ -58,11 +70,20 @@
     "name:eus_x_preferred":[
         "Awasa"
     ],
+    "name:fas_x_preferred":[
+        "\u0627\u0648\u0648\u0627\u0633\u0627"
+    ],
     "name:fin_x_preferred":[
         "Awasa"
     ],
     "name:fra_x_preferred":[
         "Awasa"
+    ],
+    "name:fra_x_variant":[
+        "Hawassa"
+    ],
+    "name:gle_x_preferred":[
+        "Hawaasa"
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab5\u0abe\u0ab8\u0abe"
@@ -79,6 +100,9 @@
     "name:hun_x_preferred":[
         "Awassa"
     ],
+    "name:hye_x_preferred":[
+        "\u0531\u0578\u0582\u0561\u057d\u0561"
+    ],
     "name:ind_x_preferred":[
         "Awasa"
     ],
@@ -87,6 +111,9 @@
     ],
     "name:jpn_x_preferred":[
         "\u30a2\u30ef\u30b5"
+    ],
+    "name:jpn_x_variant":[
+        "\u30a2\u30ef\u30c3\u30b5"
     ],
     "name:kan_x_preferred":[
         "\u0c85\u0cb5\u0cbe\u0cb8\u0cbe"
@@ -120,6 +147,9 @@
     ],
     "name:oci_x_preferred":[
         "Awasa"
+    ],
+    "name:orm_x_preferred":[
+        "Hawaasa"
     ],
     "name:pol_x_preferred":[
         "Auasa"
@@ -169,11 +199,20 @@
     "name:urd_x_preferred":[
         "\u0627\u0648\u0627\u0633\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Auasa"
+    ],
     "name:vie_x_preferred":[
         "Awasa"
     ],
+    "name:war_x_preferred":[
+        "Hawassa"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u74e6\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Awasa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -303,7 +342,7 @@
         }
     ],
     "wof:id":890418073,
-    "wof:lastmodified":1566593566,
+    "wof:lastmodified":1690879635,
     "wof:name":"Hawassa",
     "wof:parent_id":421204421,
     "wof:placetype":"locality",

--- a/data/890/418/079/890418079.geojson
+++ b/data/890/418/079/890418079.geojson
@@ -31,8 +31,14 @@
     "name:fra_x_preferred":[
         "Asebe Teferi"
     ],
+    "name:fra_x_variant":[
+        "Chiro"
+    ],
     "name:ita_x_preferred":[
         "Asba Littoria"
+    ],
+    "name:ita_x_variant":[
+        "Ciro"
     ],
     "name:nld_x_preferred":[
         "Asebe Teferi"
@@ -48,6 +54,9 @@
     ],
     "name:und_x_variant":[
         "Asbatafari"
+    ],
+    "name:zul_x_preferred":[
+        "Chiro"
     ],
     "qs:name":"\u0100sbe Tefer\u012b",
     "qs:photos_9r":0,
@@ -80,7 +89,7 @@
         }
     ],
     "wof:id":890418079,
-    "wof:lastmodified":1566593565,
+    "wof:lastmodified":1690879634,
     "wof:name":"\u0100sbe Tefer\u012b",
     "wof:parent_id":1108695227,
     "wof:placetype":"locality",

--- a/data/890/421/359/890421359.geojson
+++ b/data/890/421/359/890421359.geojson
@@ -51,7 +51,13 @@
     "name:eng_x_variant":[
         "Hadiya"
     ],
+    "name:fas_x_preferred":[
+        "\u0634\u0647\u0631\u0633\u062a\u0627\u0646 \u0647\u0627\u062f\u06cc\u0627"
+    ],
     "name:fra_x_preferred":[
+        "Hadiya"
+    ],
+    "name:ita_x_preferred":[
         "Hadiya"
     ],
     "name:jpn_x_preferred":[
@@ -63,8 +69,14 @@
     "name:swe_x_preferred":[
         "Hadiya Zone"
     ],
+    "name:swe_x_variant":[
+        "Hadiya"
+    ],
     "name:zho_x_preferred":[
         "\u54c8\u8fea\u4e9e\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Hadiya Zone"
     ],
     "qs:name":"Hadiya Zone",
     "qs:photos_9r":0,
@@ -116,7 +128,7 @@
         }
     ],
     "wof:id":890421359,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879634,
     "wof:name":"Hadiya",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/890/422/273/890422273.geojson
+++ b/data/890/422/273/890422273.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Awash"
+    ],
     "name:ceb_x_preferred":[
         "\u0100wash"
     ],
@@ -31,11 +34,20 @@
     "name:eng_x_preferred":[
         "Awash"
     ],
+    "name:fas_x_preferred":[
+        "\u0622\u0648\u0627\u0634"
+    ],
+    "name:fin_x_preferred":[
+        "Awash"
+    ],
     "name:fra_x_preferred":[
         "Awash"
     ],
     "name:hrv_x_preferred":[
         "Ava\u0161"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u057e\u0561\u0577"
     ],
     "name:ind_x_preferred":[
         "Awash"
@@ -66,6 +78,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u74e6\u4ec0"
+    ],
+    "name:zul_x_preferred":[
+        "Awash"
     ],
     "qs:name":"\u0100wash",
     "qs:photos_9r":0,
@@ -100,7 +115,7 @@
         }
     ],
     "wof:id":890422273,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1690879626,
     "wof:name":"\u0100wash",
     "wof:parent_id":1108695247,
     "wof:placetype":"locality",

--- a/data/890/428/827/890428827.geojson
+++ b/data/890/428/827/890428827.geojson
@@ -19,6 +19,15 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:amh_x_preferred":[
+        "\u12c8\u1228\u1273"
+    ],
+    "name:ast_x_preferred":[
+        "Wereta"
+    ],
+    "name:cat_x_preferred":[
+        "Wereta"
+    ],
     "name:ceb_x_preferred":[
         "Werota"
     ],
@@ -28,8 +37,14 @@
     "name:fra_x_preferred":[
         "Wereta"
     ],
+    "name:heb_x_preferred":[
+        "\u05d5\u05e8\u05d8\u05d4"
+    ],
     "name:ita_x_preferred":[
         "Wereta"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30a6\u30a9\u30ec\u30bf"
     ],
     "name:nld_x_preferred":[
         "Wereta"
@@ -45,6 +60,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6c83\u96f7\u5854"
+    ],
+    "name:zul_x_preferred":[
+        "Wereta"
     ],
     "qs:name":"Werota",
     "qs:photos_9r":0,
@@ -82,7 +100,7 @@
         }
     ],
     "wof:id":890428827,
-    "wof:lastmodified":1566593565,
+    "wof:lastmodified":1690879634,
     "wof:name":"Werota",
     "wof:parent_id":1108695205,
     "wof:placetype":"locality",

--- a/data/890/431/135/890431135.geojson
+++ b/data/890/431/135/890431135.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Maychew"
     ],
+    "name:fin_x_preferred":[
+        "Maychew"
+    ],
     "name:fra_x_preferred":[
         "Maychew"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:und_x_variant":[
         "Maych\u2019awu"
+    ],
+    "name:zul_x_preferred":[
+        "Maichew"
     ],
     "qs:name":"Maych\u2019ew",
     "qs:photos_9r":0,
@@ -88,7 +94,7 @@
         }
     ],
     "wof:id":890431135,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879631,
     "wof:name":"Maych\u2019ew",
     "wof:parent_id":1108695207,
     "wof:placetype":"locality",

--- a/data/890/431/217/890431217.geojson
+++ b/data/890/431/217/890431217.geojson
@@ -25,8 +25,14 @@
     "name:ara_x_preferred":[
         "\u0623\u062f\u0627\u0645\u0627"
     ],
+    "name:ast_x_preferred":[
+        "Adama"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0434\u0430\u043c\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u0434\u0430\u043c\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09a6\u09be\u09ae\u09be"
@@ -58,6 +64,9 @@
     "name:eus_x_preferred":[
         "Adama"
     ],
+    "name:fas_x_preferred":[
+        "\u0622\u062f\u0627\u0645\u0627"
+    ],
     "name:fin_x_preferred":[
         "Adama"
     ],
@@ -78,6 +87,9 @@
     ],
     "name:hun_x_preferred":[
         "Adama"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0564\u0561\u0574\u0561"
     ],
     "name:ind_x_preferred":[
         "Adama"
@@ -180,6 +192,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u9054\u746a"
+    ],
+    "name:zul_x_preferred":[
+        "Adama"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -304,7 +319,7 @@
         }
     ],
     "wof:id":890431217,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879631,
     "wof:name":"Nazr\u0113t",
     "wof:parent_id":1108695157,
     "wof:placetype":"locality",

--- a/data/890/431/223/890431223.geojson
+++ b/data/890/431/223/890431223.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ast_x_preferred":[
+        "Kofele"
+    ],
     "name:ceb_x_preferred":[
         "Kofel\u0113"
     ],
@@ -28,7 +31,13 @@
     "name:fra_x_preferred":[
         "Kofele"
     ],
+    "name:ita_x_preferred":[
+        "Coffol\u00e8"
+    ],
     "name:nld_x_preferred":[
+        "Kofele"
+    ],
+    "name:pol_x_preferred":[
         "Kofele"
     ],
     "name:rus_x_preferred":[
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890431223,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879632,
     "wof:name":"Kofel\u0113",
     "wof:parent_id":1108695131,
     "wof:placetype":"locality",

--- a/data/890/431/225/890431225.geojson
+++ b/data/890/431/225/890431225.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":9.0,
+    "name:ceb_x_preferred":[
+        "Kibre Mengist"
+    ],
     "name:eng_x_preferred":[
         "Kebri Mangest"
     ],
@@ -31,8 +34,14 @@
     "name:pol_x_preferred":[
         "Kebri Mangest"
     ],
+    "name:swe_x_preferred":[
+        "Kibre Mengist"
+    ],
     "name:und_x_variant":[
         "Adola"
+    ],
+    "name:zul_x_preferred":[
+        "Kebri Mangest"
     ],
     "qs:name":"Kibre Mengist",
     "qs:photos_9r":0,
@@ -67,7 +76,7 @@
         }
     ],
     "wof:id":890431225,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879632,
     "wof:name":"Kibre Mengist",
     "wof:parent_id":1108695171,
     "wof:placetype":"locality",

--- a/data/890/431/229/890431229.geojson
+++ b/data/890/431/229/890431229.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Kamisee"
+    ],
+    "name:ceb_x_preferred":[
+        "Kemis\u0113"
+    ],
     "name:eng_x_preferred":[
         "Kemise"
     ],
+    "name:eng_x_variant":[
+        "Kamisee"
+    ],
     "name:fra_x_preferred":[
         "Kemise"
+    ],
+    "name:heb_x_preferred":[
+        "\u05db\u05de\u05d9\u05e1\u05d4"
     ],
     "name:nld_x_preferred":[
         "Kemise"
@@ -31,11 +43,17 @@
     "name:pol_x_preferred":[
         "Kemise"
     ],
+    "name:swe_x_preferred":[
+        "Kemis\u0113"
+    ],
     "name:und_x_variant":[
         "Cascim"
     ],
     "name:zho_x_preferred":[
         "\u51f1\u7c73\u65af"
+    ],
+    "name:zul_x_preferred":[
+        "Kemise"
     ],
     "qs:name":"Kemis\u0113",
     "qs:photos_9r":0,
@@ -73,7 +91,7 @@
         }
     ],
     "wof:id":890431229,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879631,
     "wof:name":"Kemis\u0113",
     "wof:parent_id":1108695203,
     "wof:placetype":"locality",

--- a/data/890/431/231/890431231.geojson
+++ b/data/890/431/231/890431231.geojson
@@ -25,8 +25,17 @@
     "name:ara_x_preferred":[
         "\u0622\u0633\u0648\u0633\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0633\u0648\u0633\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Asosa"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u0441\u043e\u0441\u0430"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u0441\u043e\u0441\u0430"
     ],
     "name:ben_x_preferred":[
         "\u0986\u09b8\u09cb\u09b8\u09be"
@@ -46,6 +55,12 @@
     "name:eng_x_preferred":[
         "Asosa"
     ],
+    "name:epo_x_preferred":[
+        "Asosa"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0633\u0648\u0633\u0627"
+    ],
     "name:fin_x_preferred":[
         "Asosa"
     ],
@@ -54,6 +69,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a85\u0ab8\u0acb\u0ab8\u0abe"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d0\u05e1\u05d5\u05e1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0905\u0938\u094b\u0938"
@@ -148,8 +166,14 @@
     "name:vie_x_preferred":[
         "Asosa"
     ],
+    "name:yue_x_preferred":[
+        "\u963f\u8607\u6c99"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u7d22\u8428"
+    ],
+    "name:zul_x_preferred":[
+        "Asosa"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -276,7 +300,7 @@
         }
     ],
     "wof:id":890431231,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879632,
     "wof:name":"\u0100sosa",
     "wof:parent_id":1108695133,
     "wof:placetype":"locality",

--- a/data/890/431/235/890431235.geojson
+++ b/data/890/431/235/890431235.geojson
@@ -37,8 +37,14 @@
     "name:pol_x_preferred":[
         "Ficze"
     ],
+    "name:rus_x_preferred":[
+        "\u0424\u0438\u0448\u0435"
+    ],
     "name:swe_x_preferred":[
         "Fich\u0113"
+    ],
+    "name:zul_x_preferred":[
+        "Fiche"
     ],
     "qs:name":"Fich\u0113",
     "qs:photos_9r":0,
@@ -73,7 +79,7 @@
         }
     ],
     "wof:id":890431235,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879631,
     "wof:name":"Fich\u0113",
     "wof:parent_id":1108695199,
     "wof:placetype":"locality",

--- a/data/890/431/237/890431237.geojson
+++ b/data/890/431/237/890431237.geojson
@@ -25,7 +25,13 @@
     "name:eng_x_preferred":[
         "Deder"
     ],
+    "name:ita_x_preferred":[
+        "Ded\u00e8r"
+    ],
     "name:nld_x_preferred":[
+        "Deder"
+    ],
+    "name:pol_x_preferred":[
         "Deder"
     ],
     "name:swe_x_preferred":[
@@ -67,7 +73,7 @@
         }
     ],
     "wof:id":890431237,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879632,
     "wof:name":"Deder",
     "wof:parent_id":1108695155,
     "wof:placetype":"locality",

--- a/data/890/431/241/890431241.geojson
+++ b/data/890/431/241/890431241.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Bedessa"
+    ],
     "name:ceb_x_preferred":[
         "Bed\u0113sa"
     ],
@@ -32,6 +35,9 @@
         "Bedessa"
     ],
     "name:nld_x_preferred":[
+        "Bedessa"
+    ],
+    "name:pol_x_preferred":[
         "Bedessa"
     ],
     "name:por_x_preferred":[
@@ -48,6 +54,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8c9d\u5fb7\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Badessa"
     ],
     "qs:name":"Bed\u0113sa",
     "qs:photos_9r":0,
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890431241,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879632,
     "wof:name":"Bed\u0113sa",
     "wof:parent_id":1108695227,
     "wof:placetype":"locality",

--- a/data/890/433/309/890433309.geojson
+++ b/data/890/433/309/890433309.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Mizan Teferi"
+    ],
     "name:ceb_x_preferred":[
         "M\u012bzan Tefer\u012b"
     ],
@@ -51,6 +54,12 @@
     ],
     "name:und_x_variant":[
         "Mizon Teferi"
+    ],
+    "name:zho_x_preferred":[
+        "\u7c73\u8d5e\u7279\u8d39\u91cc"
+    ],
+    "name:zul_x_preferred":[
+        "Mizan Teferi"
     ],
     "qs:name":"M\u012bzan Tefer\u012b",
     "qs:photos_9r":0,
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890433309,
-    "wof:lastmodified":1566593566,
+    "wof:lastmodified":1690879636,
     "wof:name":"M\u012bzan Tefer\u012b",
     "wof:parent_id":890450041,
     "wof:placetype":"locality",

--- a/data/890/433/311/890433311.geojson
+++ b/data/890/433/311/890433311.geojson
@@ -19,8 +19,20 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Metehara"
+    ],
+    "name:ceb_x_preferred":[
+        "Metah\u0101ra"
+    ],
+    "name:deu_x_preferred":[
+        "Metahara"
+    ],
     "name:eng_x_preferred":[
         "Metehara"
+    ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u062a\u0647\u0627\u0631\u0627"
     ],
     "name:fra_x_preferred":[
         "Metehara"
@@ -30,6 +42,12 @@
     ],
     "name:nld_x_preferred":[
         "Metehara"
+    ],
+    "name:pol_x_preferred":[
+        "Metehara"
+    ],
+    "name:swe_x_preferred":[
+        "Metah\u0101ra"
     ],
     "name:und_x_variant":[
         "Matah\u0101r\u0101"
@@ -73,7 +91,7 @@
         }
     ],
     "wof:id":890433311,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879636,
     "wof:name":"Metah\u0101ra",
     "wof:parent_id":1108695157,
     "wof:placetype":"locality",

--- a/data/890/433/313/890433313.geojson
+++ b/data/890/433/313/890433313.geojson
@@ -31,6 +31,12 @@
     "name:fra_x_preferred":[
         "Holeta Genet"
     ],
+    "name:ita_x_preferred":[
+        "Olett\u00e0"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30db\u30ec\u30bf"
+    ],
     "name:nld_x_preferred":[
         "Holeta Genet"
     ],
@@ -42,6 +48,9 @@
     ],
     "name:und_x_variant":[
         "Oletta"
+    ],
+    "name:zul_x_preferred":[
+        "Holeta Genet"
     ],
     "qs:name":"Genet",
     "qs:photos_9r":0,
@@ -76,7 +85,7 @@
         }
     ],
     "wof:id":890433313,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879636,
     "wof:name":"Genet",
     "wof:parent_id":1108695239,
     "wof:placetype":"locality",

--- a/data/890/435/323/890435323.geojson
+++ b/data/890/435/323/890435323.geojson
@@ -25,6 +25,15 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0643\u064a\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u064a\u0643\u064a\u0644\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Mek'ele"
+    ],
+    "name:bel_x_preferred":[
+        "\u041c\u044d\u043a\u044d\u043b\u0435"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u0995'\u098f\u09b2\u09c7"
     ],
@@ -35,6 +44,9 @@
         "Mekele"
     ],
     "name:ceb_x_preferred":[
+        "Mekele"
+    ],
+    "name:ces_x_preferred":[
         "Mekele"
     ],
     "name:dan_x_preferred":[
@@ -67,6 +79,12 @@
     "name:fra_x_preferred":[
         "Mekele"
     ],
+    "name:gle_x_preferred":[
+        "Mek'ele"
+    ],
+    "name:glg_x_preferred":[
+        "Makalle"
+    ],
     "name:guj_x_preferred":[
         "\u0aae\u0ac7\u0a95\u0ac7\u0ab2\u0ac7"
     ],
@@ -82,6 +100,12 @@
     "name:hun_x_preferred":[
         "Mek\u2019ele"
     ],
+    "name:hye_x_preferred":[
+        "\u0544\u0565\u056f\u0565\u056c\u0565"
+    ],
+    "name:ile_x_preferred":[
+        "Mekele"
+    ],
     "name:ind_x_preferred":[
         "Mek'ele"
     ],
@@ -91,8 +115,14 @@
     "name:jpn_x_preferred":[
         "\u30e1\u30b1\u30ec"
     ],
+    "name:jpn_x_variant":[
+        "\u30e1\u30c3\u30af\u30a8\u30eb"
+    ],
     "name:kan_x_preferred":[
         "\u0cae\u0cc6\u0c95\u0cc6\u0cb2\u0cc6"
+    ],
+    "name:kat_x_preferred":[
+        "\u10db\u10d4\u10d9\u10d4\u10da\u10d4"
     ],
     "name:kor_x_preferred":[
         "\uba54\ucf08\ub808"
@@ -117,6 +147,9 @@
     ],
     "name:nld_x_preferred":[
         "Mek'ele"
+    ],
+    "name:nno_x_preferred":[
+        "Mekele"
     ],
     "name:nob_x_preferred":[
         "Mekele"
@@ -151,6 +184,9 @@
     "name:swe_x_preferred":[
         "Mekele"
     ],
+    "name:szl_x_preferred":[
+        "Mekelie"
+    ],
     "name:tam_x_preferred":[
         "\u0bae\u0bc6\u0b95\u0bcd\u0b95\u0bc1\u0bb5\u0bc7\u0bb2\u0bc7"
     ],
@@ -159,6 +195,9 @@
     ],
     "name:tha_x_preferred":[
         "\u0e40\u0e21\u0e40\u0e04\u0e40\u0e25"
+    ],
+    "name:tir_x_preferred":[
+        "\u1218\u1250\u1208"
     ],
     "name:tur_x_preferred":[
         "Mek'ele"
@@ -172,6 +211,9 @@
     "name:urd_x_preferred":[
         "\u0645\u06cc\u06a9\u06cc\u0644\u06d2"
     ],
+    "name:vec_x_preferred":[
+        "Macall\u00e8"
+    ],
     "name:vie_x_preferred":[
         "Makale"
     ],
@@ -180,6 +222,9 @@
     ],
     "name:zho_x_preferred":[
         "\u9ed8\u514b\u840a"
+    ],
+    "name:zul_x_preferred":[
+        "Mekelle"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -318,7 +363,7 @@
         }
     ],
     "wof:id":890435323,
-    "wof:lastmodified":1582362127,
+    "wof:lastmodified":1690879636,
     "wof:name":"Mekele",
     "wof:parent_id":1108695189,
     "wof:placetype":"locality",

--- a/data/890/435/897/890435897.geojson
+++ b/data/890/435/897/890435897.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Hagere Mariam"
+    ],
     "name:ceb_x_preferred":[
         "Hagere Maryam"
     ],
@@ -28,14 +31,23 @@
     "name:fra_x_preferred":[
         "Hagere Mariam"
     ],
+    "name:fra_x_variant":[
+        "Bule Hora"
+    ],
     "name:nld_x_preferred":[
         "Hagere Mariam"
     ],
     "name:pol_x_preferred":[
         "Hagere Maryam"
     ],
+    "name:rus_x_preferred":[
+        "\u0411\u0443\u043b\u0435-\u0425\u043e\u0440\u0430"
+    ],
     "name:swe_x_preferred":[
         "Hagere Maryam"
+    ],
+    "name:zul_x_preferred":[
+        "Bule Hora"
     ],
     "qs:name":"Hagere Maryam",
     "qs:photos_9r":0,
@@ -70,7 +82,7 @@
         }
     ],
     "wof:id":890435897,
-    "wof:lastmodified":1566593567,
+    "wof:lastmodified":1690879637,
     "wof:name":"Hagere Maryam",
     "wof:parent_id":421188225,
     "wof:placetype":"locality",

--- a/data/890/437/767/890437767.geojson
+++ b/data/890/437/767/890437767.geojson
@@ -19,8 +19,14 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Debarq"
+    ],
     "name:ceb_x_preferred":[
         "Debark'"
+    ],
+    "name:deu_x_preferred":[
+        "Debarq"
     ],
     "name:eng_x_preferred":[
         "Debarq"
@@ -33,6 +39,9 @@
     ],
     "name:ita_x_preferred":[
         "Debarq"
+    ],
+    "name:ita_x_variant":[
+        "Debarec"
     ],
     "name:nld_x_preferred":[
         "Debarq"
@@ -54,6 +63,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5fb7\u5df4\u723e\u683c"
+    ],
+    "name:zul_x_preferred":[
+        "Debarq"
     ],
     "qs:name":"Debark\u2019",
     "qs:photos_9r":0,
@@ -86,7 +98,7 @@
         }
     ],
     "wof:id":890437767,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879630,
     "wof:name":"Debark\u2019",
     "wof:parent_id":1108695193,
     "wof:placetype":"locality",

--- a/data/890/437/885/890437885.geojson
+++ b/data/890/437/885/890437885.geojson
@@ -67,6 +67,9 @@
     "name:und_x_variant":[
         "Addis-\u0100lam"
     ],
+    "name:zul_x_preferred":[
+        "Addis Alem"
+    ],
     "qs:name":"\u0100d\u012bs \u2018Alem",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -98,7 +101,7 @@
         }
     ],
     "wof:id":890437885,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879630,
     "wof:name":"\u0100d\u012bs \u2018Alem",
     "wof:parent_id":1108695239,
     "wof:placetype":"locality",

--- a/data/890/437/891/890437891.geojson
+++ b/data/890/437/891/890437891.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Adet"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u062a"
     ],
@@ -52,6 +55,9 @@
     "name:zho_x_preferred":[
         "\u963f\u5fb7\u7279"
     ],
+    "name:zul_x_preferred":[
+        "Adet"
+    ],
     "qs:name":"Addiet Canna",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -83,7 +89,7 @@
         }
     ],
     "wof:id":890437891,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879631,
     "wof:name":"Addiet Canna",
     "wof:parent_id":1108695223,
     "wof:placetype":"locality",

--- a/data/890/437/893/890437893.geojson
+++ b/data/890/437/893/890437893.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":-1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Abomsa"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u0628\u0648\u0645\u0633\u0627"
     ],
@@ -34,11 +37,17 @@
     "name:nld_x_preferred":[
         "Abomsa"
     ],
+    "name:pol_x_preferred":[
+        "Abomsa"
+    ],
     "name:und_x_variant":[
         "Abonsa"
     ],
     "name:zho_x_preferred":[
         "\u963f\u535a\u59c6\u85a9"
+    ],
+    "name:zul_x_preferred":[
+        "Abomsa"
     ],
     "qs:name":"Abomsa",
     "qs:photos_9r":0,
@@ -75,7 +84,7 @@
         }
     ],
     "wof:id":890437893,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879630,
     "wof:name":"Abomsa",
     "wof:parent_id":1108695197,
     "wof:placetype":"locality",

--- a/data/890/438/205/890438205.geojson
+++ b/data/890/438/205/890438205.geojson
@@ -22,11 +22,29 @@
     "name:amh_x_preferred":[
         "\u12a5\u1295\u12f3\u1235\u120b\u1234"
     ],
+    "name:ara_x_preferred":[
+        "\u0634\u0627\u064a\u0631"
+    ],
+    "name:bar_x_preferred":[
+        "Shire"
+    ],
+    "name:bel_x_preferred":[
+        "\u042b\u043d\u0434\u0430-\u0421\u044b\u043b\u0430\u0441\u0435"
+    ],
     "name:ceb_x_preferred":[
         "Inda Silas\u0113"
     ],
+    "name:deu_x_preferred":[
+        "Shire"
+    ],
     "name:eng_x_preferred":[
         "Shire"
+    ],
+    "name:est_x_preferred":[
+        "Shire Inda Selassie"
+    ],
+    "name:fin_x_preferred":[
+        "Inda Silase"
     ],
     "name:fra_x_preferred":[
         "Shire"
@@ -55,6 +73,9 @@
     "name:slv_x_preferred":[
         "Shire"
     ],
+    "name:swa_x_preferred":[
+        "Shire"
+    ],
     "name:swe_x_preferred":[
         "Inda Silas\u0113"
     ],
@@ -66,6 +87,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e0c\u96f7"
+    ],
+    "name:zul_x_preferred":[
+        "Shire Inda Selassie"
     ],
     "qs:name":"Inda Silas\u0113",
     "qs:photos_9r":0,
@@ -98,7 +122,7 @@
         }
     ],
     "wof:id":890438205,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879633,
     "wof:name":"Inda Silas\u0113",
     "wof:parent_id":1108695229,
     "wof:placetype":"locality",

--- a/data/890/438/411/890438411.geojson
+++ b/data/890/438/411/890438411.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Mendi"
+    ],
+    "name:ceb_x_preferred":[
+        "Mend\u012b"
+    ],
     "name:eng_x_preferred":[
         "Mendi"
     ],
@@ -31,14 +37,23 @@
     "name:nld_x_preferred":[
         "Mendi"
     ],
+    "name:pol_x_preferred":[
+        "Mendi"
+    ],
     "name:rus_x_preferred":[
         "\u041c\u0435\u043d\u0434\u0438"
     ],
     "name:spa_x_preferred":[
         "Mendi"
     ],
+    "name:swe_x_preferred":[
+        "Mend\u012b"
+    ],
     "name:und_x_variant":[
         "Mandi"
+    ],
+    "name:zul_x_preferred":[
+        "Mendi"
     ],
     "qs:name":"Mend\u012b",
     "qs:photos_9r":0,
@@ -73,7 +88,7 @@
         }
     ],
     "wof:id":890438411,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879633,
     "wof:name":"Mend\u012b",
     "wof:parent_id":1108695233,
     "wof:placetype":"locality",

--- a/data/890/440/169/890440169.geojson
+++ b/data/890/440/169/890440169.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0622\u062f\u064a\u063a\u0631\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u062f\u064a\u062c\u0631\u0627\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Adigrat"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u062f\u06cc\u0642\u0631\u0627\u062a"
     ],
@@ -121,6 +127,9 @@
     "name:spa_x_preferred":[
         "Adigrat"
     ],
+    "name:swa_x_preferred":[
+        "Adigrat"
+    ],
     "name:swe_x_preferred":[
         "Adigrat"
     ],
@@ -150,6 +159,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u8fea\u683c\u62c9\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Adigrat"
     ],
     "qs:name":"\u0100d\u012bgrat",
     "qs:photos_9r":0,
@@ -182,7 +194,7 @@
         }
     ],
     "wof:id":890440169,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1690879625,
     "wof:name":"\u0100d\u012bgrat",
     "wof:parent_id":1108695161,
     "wof:placetype":"locality",

--- a/data/890/440/349/890440349.geojson
+++ b/data/890/440/349/890440349.geojson
@@ -19,11 +19,23 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ara_x_preferred":[
+        "\u0645\u0627\u062a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Metu"
+    ],
+    "name:ceb_x_preferred":[
+        "Metu"
+    ],
     "name:eng_x_preferred":[
         "Metu"
     ],
     "name:fra_x_preferred":[
         "Metou"
+    ],
+    "name:fra_x_variant":[
+        "Metu"
     ],
     "name:hrv_x_preferred":[
         "Metu"
@@ -43,11 +55,17 @@
     "name:rus_x_preferred":[
         "\u041c\u044d\u0442\u0442\u0443"
     ],
+    "name:swe_x_preferred":[
+        "Metu"
+    ],
     "name:und_x_variant":[
         "Mattu"
     ],
     "name:zho_x_preferred":[
         "\u9ed8\u5716"
+    ],
+    "name:zul_x_preferred":[
+        "Metu"
     ],
     "qs:name":"Metu",
     "qs:photos_9r":0,
@@ -80,7 +98,7 @@
         }
     ],
     "wof:id":890440349,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1690879626,
     "wof:name":"Metu",
     "wof:parent_id":890446963,
     "wof:placetype":"locality",

--- a/data/890/440/351/890440351.geojson
+++ b/data/890/440/351/890440351.geojson
@@ -22,6 +22,9 @@
     "name:ara_x_preferred":[
         "\u062f\u0627\u0628\u0627\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u0627\u0628\u0627\u062a"
+    ],
     "name:ceb_x_preferred":[
         "Dabat"
     ],
@@ -36,6 +39,9 @@
     ],
     "name:und_x_variant":[
         "Dahat"
+    ],
+    "name:zul_x_preferred":[
+        "Dabat"
     ],
     "qs:name":"Dabat",
     "qs:photos_9r":0,
@@ -70,7 +76,7 @@
         }
     ],
     "wof:id":890440351,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1690879626,
     "wof:name":"Dabat",
     "wof:parent_id":1108695193,
     "wof:placetype":"locality",

--- a/data/890/441/249/890441249.geojson
+++ b/data/890/441/249/890441249.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_variant":[
         "\u063a\u0627\u0645\u0628\u064a\u0644\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0627\u0645\u0628\u064a\u0644\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Gambela"
+    ],
     "name:ben_x_preferred":[
         "\u0997\u09be\u09ae\u09cd\u09ac\u09c7\u09b2\u09be"
     ],
@@ -45,6 +51,12 @@
     ],
     "name:eng_x_preferred":[
         "Gambela"
+    ],
+    "name:epo_x_preferred":[
+        "Gambelo"
+    ],
+    "name:fas_x_preferred":[
+        "\u06af\u0627\u0645\u0628\u0644\u0627"
     ],
     "name:fin_x_preferred":[
         "Gambela"
@@ -151,6 +163,9 @@
     "name:zho_x_preferred":[
         "\u7518\u8d1d\u62c9"
     ],
+    "name:zul_x_preferred":[
+        "Gambela"
+    ],
     "qs:name":"Gamb\u0113la",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -184,7 +199,7 @@
         }
     ],
     "wof:id":890441249,
-    "wof:lastmodified":1566593562,
+    "wof:lastmodified":1690879629,
     "wof:name":"Gamb\u0113la",
     "wof:parent_id":421188217,
     "wof:placetype":"locality",

--- a/data/890/441/251/890441251.geojson
+++ b/data/890/441/251/890441251.geojson
@@ -22,6 +22,12 @@
     "name:amh_x_preferred":[
         "\u1266\u1295\u130b"
     ],
+    "name:ast_x_preferred":[
+        "Bonga"
+    ],
+    "name:ceb_x_preferred":[
+        "Bonga"
+    ],
     "name:deu_x_preferred":[
         "Bonga"
     ],
@@ -33,6 +39,9 @@
     ],
     "name:ita_x_preferred":[
         "Bonga"
+    ],
+    "name:jpn_x_preferred":[
+        "\u30dc\u30f3\u30ac"
     ],
     "name:nld_x_preferred":[
         "Bonga"
@@ -46,11 +55,17 @@
     "name:rus_x_preferred":[
         "\u0411\u043e\u043d\u0433\u0430"
     ],
+    "name:swe_x_preferred":[
+        "Bonga"
+    ],
     "name:und_x_variant":[
         "Bonga (1)"
     ],
     "name:zho_x_preferred":[
         "\u90a6\u52a0"
+    ],
+    "name:zul_x_preferred":[
+        "Bonga"
     ],
     "qs:name":"Bonga",
     "qs:photos_9r":0,
@@ -88,7 +103,7 @@
         }
     ],
     "wof:id":890441251,
-    "wof:lastmodified":1566593562,
+    "wof:lastmodified":1690879628,
     "wof:name":"Bonga",
     "wof:parent_id":1108695181,
     "wof:placetype":"locality",

--- a/data/890/441/255/890441255.geojson
+++ b/data/890/441/255/890441255.geojson
@@ -49,6 +49,9 @@
     "name:zho_x_preferred":[
         "\u535a\u8fea\u63d0"
     ],
+    "name:zul_x_preferred":[
+        "Boditi"
+    ],
     "qs:name":"Bod\u012bt\u012b",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":890441255,
-    "wof:lastmodified":1566593563,
+    "wof:lastmodified":1690879630,
     "wof:name":"Bod\u012bt\u012b",
     "wof:parent_id":1108695237,
     "wof:placetype":"locality",

--- a/data/890/441/611/890441611.geojson
+++ b/data/890/441/611/890441611.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Tepi"
+    ],
     "name:bul_x_preferred":[
         "\u0422\u0438\u043f\u0438"
     ],
@@ -33,6 +36,9 @@
     ],
     "name:fra_x_preferred":[
         "Tippi"
+    ],
+    "name:fra_x_variant":[
+        "Tepi"
     ],
     "name:hun_x_preferred":[
         "Tepi"
@@ -60,6 +66,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7279\u6bd4"
+    ],
+    "name:zul_x_preferred":[
+        "Tepi"
     ],
     "qs:name":"Tippi",
     "qs:photos_9r":0,
@@ -94,7 +103,7 @@
         }
     ],
     "wof:id":890441611,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879628,
     "wof:name":"Tippi",
     "wof:parent_id":1108695217,
     "wof:placetype":"locality",

--- a/data/890/441/617/890441617.geojson
+++ b/data/890/441/617/890441617.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Shakiso"
+    ],
     "name:ceb_x_preferred":[
         "Shak\u012bso"
     ],
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":890441617,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879627,
     "wof:name":"Shak\u012bso",
     "wof:parent_id":1108695171,
     "wof:placetype":"locality",

--- a/data/890/441/621/890441621.geojson
+++ b/data/890/441/621/890441621.geojson
@@ -28,6 +28,9 @@
     "name:eng_x_preferred":[
         "Mojo"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0648\u062c\u0648"
+    ],
     "name:fra_x_preferred":[
         "Mojo"
     ],
@@ -54,6 +57,9 @@
     ],
     "name:und_x_variant":[
         "Maggio"
+    ],
+    "name:zul_x_preferred":[
+        "Mojo"
     ],
     "qs:name":"Mojo",
     "qs:photos_9r":0,
@@ -88,7 +94,7 @@
         }
     ],
     "wof:id":890441621,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879627,
     "wof:name":"Mojo",
     "wof:parent_id":1108695157,
     "wof:placetype":"locality",

--- a/data/890/441/623/890441623.geojson
+++ b/data/890/441/623/890441623.geojson
@@ -49,11 +49,17 @@
     "name:ron_x_preferred":[
         "Jinka"
     ],
+    "name:rus_x_preferred":[
+        "\u0414\u0436\u0438\u043d\u043a\u0430"
+    ],
     "name:swe_x_preferred":[
         "Jinka"
     ],
     "name:zho_x_preferred":[
         "\u91d1\u5361"
+    ],
+    "name:zul_x_preferred":[
+        "Jinka"
     ],
     "qs:name":"Jinka",
     "qs:photos_9r":0,
@@ -87,7 +93,7 @@
         }
     ],
     "wof:id":890441623,
-    "wof:lastmodified":1566593562,
+    "wof:lastmodified":1690879629,
     "wof:name":"Jinka",
     "wof:parent_id":1108695219,
     "wof:placetype":"locality",

--- a/data/890/441/625/890441625.geojson
+++ b/data/890/441/625/890441625.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":11.0,
+    "name:ceb_x_preferred":[
+        "Debre S\u012bna"
+    ],
     "name:eng_x_preferred":[
         "Debre Sina"
     ],
@@ -27,6 +30,9 @@
     ],
     "name:nld_x_preferred":[
         "Debre Sina"
+    ],
+    "name:swe_x_preferred":[
+        "Debre S\u012bna"
     ],
     "name:und_x_variant":[
         "Debra Sina"
@@ -64,7 +70,7 @@
         }
     ],
     "wof:id":890441625,
-    "wof:lastmodified":1566593562,
+    "wof:lastmodified":1690879628,
     "wof:name":"Debre S\u012bna",
     "wof:parent_id":1108695197,
     "wof:placetype":"locality",

--- a/data/890/441/627/890441627.geojson
+++ b/data/890/441/627/890441627.geojson
@@ -22,6 +22,12 @@
     "name:amh_x_preferred":[
         "\u1261\u1273\u1305\u122b"
     ],
+    "name:ara_x_preferred":[
+        "\u0628\u0648\u062a\u0627\u062c\u064a\u0631\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Butajira"
+    ],
     "name:ceb_x_preferred":[
         "Butaj\u012bra"
     ],
@@ -48,6 +54,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5e03\u5854\u5409\u62c9"
+    ],
+    "name:zul_x_preferred":[
+        "Butajira"
     ],
     "qs:name":"Butaj\u012bra",
     "qs:photos_9r":0,
@@ -85,7 +94,7 @@
         }
     ],
     "wof:id":890441627,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879627,
     "wof:name":"Butaj\u012bra",
     "wof:parent_id":421182273,
     "wof:placetype":"locality",

--- a/data/890/441/629/890441629.geojson
+++ b/data/890/441/629/890441629.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0633\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0633\u0649"
+    ],
+    "name:ast_x_preferred":[
+        "Dessie"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u044d\u0441\u044d"
     ],
@@ -55,14 +61,23 @@
     "name:eus_x_preferred":[
         "Dese"
     ],
+    "name:fas_x_preferred":[
+        "\u062f\u06cc\u0633\u06cc"
+    ],
     "name:fin_x_preferred":[
         "Dessie"
     ],
     "name:fra_x_preferred":[
         "Dessie"
     ],
+    "name:gle_x_preferred":[
+        "Dessie"
+    ],
     "name:guj_x_preferred":[
         "\u0aa1\u0ac7\u0ab8\u0ac0"
+    ],
+    "name:heb_x_preferred":[
+        "\u05d3\u05e1\u05d4"
     ],
     "name:hin_x_preferred":[
         "\u0926\u0947\u0938\u094d\u0938\u0940"
@@ -127,6 +142,9 @@
     "name:spa_x_preferred":[
         "Dese"
     ],
+    "name:swa_x_preferred":[
+        "Dese"
+    ],
     "name:swe_x_preferred":[
         "Dese"
     ],
@@ -151,6 +169,9 @@
     "name:urd_x_preferred":[
         "\u062f\u06cc\u0633\u06cc\u06cc"
     ],
+    "name:vec_x_preferred":[
+        "Dessi\u00e8"
+    ],
     "name:vie_x_preferred":[
         "Dessie"
     ],
@@ -159,6 +180,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5fb7\u897f"
+    ],
+    "name:zul_x_preferred":[
+        "Dessie"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -288,7 +312,7 @@
         }
     ],
     "wof:id":890441629,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879627,
     "wof:name":"Des\u0113",
     "wof:parent_id":1108695209,
     "wof:placetype":"locality",

--- a/data/890/441/633/890441633.geojson
+++ b/data/890/441/633/890441633.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:ast_x_preferred":[
+        "Bure"
+    ],
     "name:ceb_x_preferred":[
         "Bur\u0113"
     ],
@@ -77,7 +80,7 @@
         }
     ],
     "wof:id":890441633,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879628,
     "wof:name":"Bur\u0113",
     "wof:parent_id":1108695223,
     "wof:placetype":"locality",

--- a/data/890/441/635/890441635.geojson
+++ b/data/890/441/635/890441635.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0628\u0631\u064a \u0645\u0627\u0631\u0643\u0648\u0633"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0628\u0631\u0649 \u0645\u0627\u0631\u0643\u0648\u0633"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u044d\u0431\u0440\u044d-\u041c\u0430\u0440\u043a\u0430\u0441"
     ],
@@ -48,6 +51,9 @@
     ],
     "name:epo_x_preferred":[
         "Debre Markos"
+    ],
+    "name:fas_x_preferred":[
+        "\u062f\u0628\u0631\u0647 \u0645\u0627\u0631\u06a9\u0648\u0633"
     ],
     "name:fin_x_preferred":[
         "Debre Marqos"
@@ -118,6 +124,9 @@
     "name:spa_x_preferred":[
         "Debre Markos"
     ],
+    "name:swa_x_preferred":[
+        "Debre Mark'os"
+    ],
     "name:swe_x_preferred":[
         "Debre Mark'os"
     ],
@@ -143,6 +152,12 @@
         "\u062f\u06cc\u0628\u0631\u06cc \u0645\u0631\u0642\u0648\u0633"
     ],
     "name:vie_x_preferred":[
+        "Debre Marqos"
+    ],
+    "name:yue_x_preferred":[
+        "\u5fb7\u6ce2\u5229\u99ac\u9ad8\u65af"
+    ],
+    "name:zul_x_preferred":[
         "Debre Marqos"
     ],
     "ne:ADM0CAP":0.0,
@@ -270,7 +285,7 @@
         }
     ],
     "wof:id":890441635,
-    "wof:lastmodified":1566593561,
+    "wof:lastmodified":1690879628,
     "wof:name":"Debre Mark\u2019os",
     "wof:parent_id":1108695153,
     "wof:placetype":"locality",

--- a/data/890/441/637/890441637.geojson
+++ b/data/890/441/637/890441637.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u062f\u064a\u0628\u0631\u064a \u0628\u064a\u0631\u0647\u0627\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u062f\u064a\u0628\u0631\u0649 \u0628\u064a\u0631\u0647\u0627\u0646"
+    ],
     "name:ben_x_preferred":[
         "\u09a1\u09c7\u09ac\u09cd\u09b0\u09bf \u09ac\u09c7\u09b0\u09b9\u09be"
     ],
@@ -42,6 +45,9 @@
     ],
     "name:eng_x_preferred":[
         "Debre Berhan"
+    ],
+    "name:fas_x_preferred":[
+        "\u062f\u0628\u0631\u0647 \u0628\u0631\u0647\u0627\u0646"
     ],
     "name:fin_x_preferred":[
         "Debre Berhan"
@@ -118,6 +124,9 @@
     "name:spa_x_preferred":[
         "Debre Berhan"
     ],
+    "name:swa_x_preferred":[
+        "Debre Birhan"
+    ],
     "name:swe_x_preferred":[
         "Debre Birhan"
     ],
@@ -143,6 +152,12 @@
         "\u062f\u06cc\u0628\u0631\u06cc \u0628\u06cc\u0631\u062d\u0627\u0646"
     ],
     "name:vie_x_preferred":[
+        "Debre Berhan"
+    ],
+    "name:zho_x_preferred":[
+        "\u5fb7\u4f2f\u52d2\u4f2f\u723e\u6f22"
+    ],
+    "name:zul_x_preferred":[
         "Debre Berhan"
     ],
     "ne:ADM0CAP":0.0,
@@ -279,7 +294,7 @@
         }
     ],
     "wof:id":890441637,
-    "wof:lastmodified":1636503448,
+    "wof:lastmodified":1690879629,
     "wof:name":"Debre Birhan",
     "wof:parent_id":1108695197,
     "wof:placetype":"locality",

--- a/data/890/441/641/890441641.geojson
+++ b/data/890/441/641/890441641.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u0622\u0631\u0628\u0627 \u0645\u064a\u0646\u0634"
     ],
+    "name:arz_x_preferred":[
+        "\u0622\u0631\u0628\u0627 \u0645\u064a\u0646\u0634"
+    ],
+    "name:ast_x_preferred":[
+        "Arba Minch"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09b0\u09cd\u09ac\u09be \u09ae\u09bf\u09cd\u09a8\u09b8"
     ],
@@ -42,6 +48,9 @@
     ],
     "name:eng_x_preferred":[
         "Arba Minch"
+    ],
+    "name:fas_x_preferred":[
+        "\u0622\u0631\u0628\u0627 \u0645\u06cc\u0646\u0686"
     ],
     "name:fin_x_preferred":[
         "Arba Minch"
@@ -115,6 +124,9 @@
     "name:spa_x_preferred":[
         "Arba Minch"
     ],
+    "name:swa_x_preferred":[
+        "Arba Minch"
+    ],
     "name:swe_x_preferred":[
         "Arba Minch"
     ],
@@ -144,6 +156,9 @@
     ],
     "name:zho_x_preferred":[
         "\u963f\u723e\u5df4\u9580\u5947"
+    ],
+    "name:zul_x_preferred":[
+        "Arba Minch"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -270,7 +285,7 @@
         }
     ],
     "wof:id":890441641,
-    "wof:lastmodified":1566593562,
+    "wof:lastmodified":1690879629,
     "wof:name":"\u0100rba Minch\u2019",
     "wof:parent_id":1108695167,
     "wof:placetype":"locality",

--- a/data/890/441/643/890441643.geojson
+++ b/data/890/441/643/890441643.geojson
@@ -19,6 +19,12 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":9.0,
+    "name:amh_x_preferred":[
+        "\u12a0\u1228\u12ab"
+    ],
+    "name:ast_x_preferred":[
+        "Areka"
+    ],
     "name:ceb_x_preferred":[
         "\u0100reka"
     ],
@@ -39,6 +45,9 @@
     ],
     "name:und_x_variant":[
         "Ancheto"
+    ],
+    "name:zul_x_preferred":[
+        "Areka"
     ],
     "qs:name":"\u0100reka",
     "qs:photos_9r":0,
@@ -73,7 +82,7 @@
         }
     ],
     "wof:id":890441643,
-    "wof:lastmodified":1566593560,
+    "wof:lastmodified":1690879627,
     "wof:name":"\u0100reka",
     "wof:parent_id":1108695237,
     "wof:placetype":"locality",

--- a/data/890/442/041/890442041.geojson
+++ b/data/890/442/041/890442041.geojson
@@ -25,6 +25,12 @@
     "name:ara_x_preferred":[
         "\u062c\u064a\u0645\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u0645\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Jimma"
+    ],
     "name:ben_x_preferred":[
         "\u099c\u09bf\u09ae\u09cd\u09ae\u09be"
     ],
@@ -52,10 +58,16 @@
     "name:eus_x_preferred":[
         "Jima"
     ],
+    "name:fas_x_preferred":[
+        "\u062c\u06cc\u0645\u0627"
+    ],
     "name:fin_x_preferred":[
         "Jimma"
     ],
     "name:fra_x_preferred":[
+        "Jimma"
+    ],
+    "name:gle_x_preferred":[
         "Jimma"
     ],
     "name:guj_x_preferred":[
@@ -133,8 +145,14 @@
     "name:spa_x_preferred":[
         "Jima"
     ],
+    "name:swa_x_preferred":[
+        "Jimma"
+    ],
     "name:swe_x_preferred":[
         "Jimma"
+    ],
+    "name:swe_x_variant":[
+        "Jima"
     ],
     "name:tam_x_preferred":[
         "\u0b9c\u0bc0\u0bae\u0bcd\u0bae\u0bbe"
@@ -157,6 +175,9 @@
     "name:urd_x_preferred":[
         "\u062c\u06cc\u0645\u0645\u0627"
     ],
+    "name:vec_x_preferred":[
+        "Gimma"
+    ],
     "name:vie_x_preferred":[
         "Jimma"
     ],
@@ -165,6 +186,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5409\u99ac"
+    ],
+    "name:zul_x_preferred":[
+        "Jimma"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -295,7 +319,7 @@
         }
     ],
     "wof:id":890442041,
-    "wof:lastmodified":1566593566,
+    "wof:lastmodified":1690879635,
     "wof:name":"J\u012bma",
     "wof:parent_id":890418071,
     "wof:placetype":"locality",

--- a/data/890/442/043/890442043.geojson
+++ b/data/890/442/043/890442043.geojson
@@ -28,6 +28,12 @@
     "name:ara_x_preferred":[
         "\u0642\u0648\u0646\u062f\u0631"
     ],
+    "name:ara_x_variant":[
+        "\u063a\u0648\u0646\u062f\u0631"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0646\u062f\u0631"
+    ],
     "name:ast_x_preferred":[
         "Gondar"
     ],
@@ -51,6 +57,9 @@
     ],
     "name:cat_x_preferred":[
         "Gondar"
+    ],
+    "name:cat_x_variant":[
+        "Gonder"
     ],
     "name:ceb_x_preferred":[
         "Gondar"
@@ -88,6 +97,9 @@
     "name:fra_x_preferred":[
         "Gondar"
     ],
+    "name:gle_x_preferred":[
+        "Gondar"
+    ],
     "name:glg_x_preferred":[
         "Gondar"
     ],
@@ -107,6 +119,12 @@
         "Gondar"
     ],
     "name:hun_x_preferred":[
+        "Gondar"
+    ],
+    "name:hye_x_preferred":[
+        "\u0533\u0578\u0576\u0564\u0565\u0580"
+    ],
+    "name:ile_x_preferred":[
         "Gondar"
     ],
     "name:ind_x_preferred":[
@@ -138,6 +156,9 @@
     ],
     "name:mar_x_preferred":[
         "\u0917\u094b\u0902\u0926\u0930"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0413\u043e\u043d\u0434\u044d\u0440"
     ],
     "name:mon_x_preferred":[
         "\u0413\u043e\u043d\u0434\u044d\u0440"
@@ -205,8 +226,14 @@
     "name:ukr_x_preferred":[
         "\u0413\u043e\u043d\u0434\u0435\u0440"
     ],
+    "name:ukr_x_variant":[
+        "\u0490\u043e\u043d\u0434\u0435\u0440"
+    ],
     "name:urd_x_preferred":[
         "\u062c\u0648\u0646\u062f\u0627\u0631"
+    ],
+    "name:vec_x_preferred":[
+        "Gondar"
     ],
     "name:vie_x_preferred":[
         "Gondar"
@@ -216,6 +243,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8ca2\u5fb7\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Gondar"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Ethiopia",
@@ -351,7 +381,7 @@
         }
     ],
     "wof:id":890442043,
-    "wof:lastmodified":1582362127,
+    "wof:lastmodified":1690879635,
     "wof:name":"Gonder",
     "wof:parent_id":1108695193,
     "wof:placetype":"locality",

--- a/data/890/443/213/890443213.geojson
+++ b/data/890/443/213/890443213.geojson
@@ -34,11 +34,20 @@
     "name:ast_x_preferred":[
         "Aksum"
     ],
+    "name:avk_x_preferred":[
+        "Aksum"
+    ],
     "name:azb_x_preferred":[
         "\u0627\u06a9\u0633\u0648\u0645"
     ],
+    "name:aze_x_preferred":[
+        "Aksum"
+    ],
     "name:bel_x_preferred":[
         "\u0413\u043e\u0440\u0430\u0434 \u0410\u043a\u0441\u0443\u043c"
+    ],
+    "name:bel_x_variant":[
+        "\u0410\u043a\u0441\u0443\u043c"
     ],
     "name:ben_x_preferred":[
         "\u0986\u0995\u09b8\u09c1\u09ae"
@@ -51,6 +60,9 @@
     ],
     "name:cat_x_preferred":[
         "Aksum"
+    ],
+    "name:cat_x_variant":[
+        "Axum"
     ],
     "name:ceb_x_preferred":[
         "\u0100ksum"
@@ -114,6 +126,9 @@
     ],
     "name:hun_x_preferred":[
         "Aksz\u00fam"
+    ],
+    "name:hye_x_preferred":[
+        "\u0531\u0584\u057d\u0578\u0582\u0574"
     ],
     "name:ind_x_preferred":[
         "Aksum"
@@ -196,6 +211,12 @@
     "name:slv_x_preferred":[
         "Aksum"
     ],
+    "name:smn_x_preferred":[
+        "Aksum"
+    ],
+    "name:sms_x_preferred":[
+        "Aksumm"
+    ],
     "name:spa_x_preferred":[
         "Aksum"
     ],
@@ -226,6 +247,9 @@
     "name:urd_x_preferred":[
         "\u0627\u0632\u0648\u0645"
     ],
+    "name:urd_x_variant":[
+        "\u0627\u06a9\u0633\u0648\u0645"
+    ],
     "name:vec_x_preferred":[
         "Axum"
     ],
@@ -235,11 +259,20 @@
     "name:war_x_preferred":[
         "Aksum"
     ],
+    "name:wuu_x_preferred":[
+        "\u963f\u514b\u82cf\u59c6"
+    ],
     "name:xmf_x_preferred":[
         "\u10d0\u10e5\u10e1\u10e3\u10db\u10d8"
     ],
+    "name:yue_x_preferred":[
+        "\u963f\u514b\u8607\u59c6"
+    ],
     "name:zho_x_preferred":[
         "\u963f\u514b\u8607\u59c6"
+    ],
+    "name:zul_x_preferred":[
+        "Axum"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"Bolivia",
@@ -364,7 +397,7 @@
         }
     ],
     "wof:id":890443213,
-    "wof:lastmodified":1566593565,
+    "wof:lastmodified":1690879634,
     "wof:name":"\u0100ksum",
     "wof:parent_id":1108695145,
     "wof:placetype":"locality",

--- a/data/890/446/963/890446963.geojson
+++ b/data/890/446/963/890446963.geojson
@@ -36,6 +36,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":6.0,
+    "name:cat_x_preferred":[
+        "Ilubabor"
+    ],
     "name:ceb_x_preferred":[
         "Illubabor Zone"
     ],
@@ -64,8 +67,14 @@
     "name:swe_x_preferred":[
         "Illubabor Zone"
     ],
+    "name:swe_x_variant":[
+        "Illubabor"
+    ],
     "name:zho_x_preferred":[
         "\u4f0a\u8def\u5df4\u535a"
+    ],
+    "name:zul_x_preferred":[
+        "Illubabor Zone"
     ],
     "qs:name":"Illubabor Zone",
     "qs:photos_9r":0,
@@ -117,7 +126,7 @@
         }
     ],
     "wof:id":890446963,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1690879626,
     "wof:name":"Illubabor",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/890/450/041/890450041.geojson
+++ b/data/890/450/041/890450041.geojson
@@ -43,10 +43,17 @@
         "Bench Maji Zone"
     ],
     "name:eng_x_variant":[
-        "Bench Maji"
+        "Bench Maji",
+        "Bench Sheko"
     ],
     "name:fra_x_preferred":[
         "Bench Maji"
+    ],
+    "name:fra_x_variant":[
+        "Bench Sheko"
+    ],
+    "name:ita_x_preferred":[
+        "Bench Sheko"
     ],
     "name:jpn_x_preferred":[
         "\u30d9\u30f3\u30c1\u30fb\u30de\u30b8\u5730\u65b9"
@@ -57,11 +64,17 @@
     "name:swe_x_preferred":[
         "Bench Maji Zone"
     ],
+    "name:swe_x_variant":[
+        "Bench Maji"
+    ],
     "name:und_x_variant":[
         "Benchi"
     ],
     "name:zho_x_preferred":[
         "\u672c\u5947\u99ac\u5409\u5730\u5340"
+    ],
+    "name:zul_x_preferred":[
+        "Bench Maji Zone"
     ],
     "qs:name":"Bench Maji Zone",
     "qs:photos_9r":0,
@@ -113,7 +126,7 @@
         }
     ],
     "wof:id":890450041,
-    "wof:lastmodified":1582362127,
+    "wof:lastmodified":1690879636,
     "wof:name":"Bench Maji",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/890/453/469/890453469.geojson
+++ b/data/890/453/469/890453469.geojson
@@ -25,6 +25,9 @@
     "name:eng_x_preferred":[
         "Hirna"
     ],
+    "name:ita_x_preferred":[
+        "Hirna"
+    ],
     "name:nld_x_preferred":[
         "Hirna"
     ],
@@ -64,7 +67,7 @@
         }
     ],
     "wof:id":890453469,
-    "wof:lastmodified":1566593565,
+    "wof:lastmodified":1690879634,
     "wof:name":"H\u012brna",
     "wof:parent_id":1108695227,
     "wof:placetype":"locality",

--- a/data/890/453/471/890453471.geojson
+++ b/data/890/453/471/890453471.geojson
@@ -28,6 +28,9 @@
     "name:fra_x_preferred":[
         "Hagere Selam"
     ],
+    "name:ita_x_preferred":[
+        "Agheresalam"
+    ],
     "name:nld_x_preferred":[
         "Hagere Selam"
     ],
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":890453471,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879633,
     "wof:name":"H\u0101gere Selam",
     "wof:parent_id":421204421,
     "wof:placetype":"locality",

--- a/data/890/453/473/890453473.geojson
+++ b/data/890/453/473/890453473.geojson
@@ -19,6 +19,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":10.0,
+    "name:ast_x_preferred":[
+        "Gewane"
+    ],
     "name:ceb_x_preferred":[
         "Gewan\u0113"
     ],
@@ -75,7 +78,7 @@
         }
     ],
     "wof:id":890453473,
-    "wof:lastmodified":1566593565,
+    "wof:lastmodified":1690879633,
     "wof:name":"Gewan\u0113",
     "wof:parent_id":1108695247,
     "wof:placetype":"locality",

--- a/data/890/454/335/890454335.geojson
+++ b/data/890/454/335/890454335.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0645\u0631\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0645\u0631\u0627"
+    ],
     "name:bul_x_preferred":[
         "\u0421\u0435\u043c\u0435\u0440\u0430"
     ],
@@ -43,6 +46,15 @@
     "name:eng_x_preferred":[
         "Semera"
     ],
+    "name:epo_x_preferred":[
+        "Semera"
+    ],
+    "name:fas_x_preferred":[
+        "\u0633\u0645\u0631\u0627"
+    ],
+    "name:fin_x_preferred":[
+        "Semera"
+    ],
     "name:fra_x_preferred":[
         "Semera"
     ],
@@ -53,6 +65,12 @@
         "\u05e1\u05d0\u05de\u05e8\u05d4"
     ],
     "name:hun_x_preferred":[
+        "Semera"
+    ],
+    "name:ile_x_preferred":[
+        "Semera"
+    ],
+    "name:ita_x_preferred":[
         "Semera"
     ],
     "name:jpn_x_preferred":[
@@ -67,7 +85,13 @@
     "name:lit_x_preferred":[
         "Semera"
     ],
+    "name:mkd_x_preferred":[
+        "\u0421\u0435\u043c\u0435\u0440\u0430"
+    ],
     "name:nld_x_preferred":[
+        "Semera"
+    ],
+    "name:ron_x_preferred":[
         "Semera"
     ],
     "name:rus_x_preferred":[
@@ -75,6 +99,9 @@
     ],
     "name:swe_x_preferred":[
         "Semera"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0421\u0435\u043c\u0435\u0440\u0430"
     ],
     "name:urd_x_preferred":[
         "\u0633\u06cc\u0645\u06cc\u0631\u0627"
@@ -115,7 +142,7 @@
         }
     ],
     "wof:id":890454335,
-    "wof:lastmodified":1566593564,
+    "wof:lastmodified":1690879633,
     "wof:name":"Semera",
     "wof:parent_id":1108695243,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.