### PR TITLE
et concordances, placetype local, and more

### DIFF
--- a/data/110/869/510/9/1108695109.geojson
+++ b/data/110/869/510/9/1108695109.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000635,
-    "geom:area_square_m":7757491.113034,
+    "geom:area_square_m":7757491.113033,
     "geom:bbox":"38.719097,9.008665,38.755924,9.032926",
     "geom:latitude":9.021863,
     "geom:longitude":38.736667,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AA.ON"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493449,
-    "wof:geomhash":"2ed7078d9715c9d4b40a4d97f42de84e",
+    "wof:geomhash":"013a8423a7060f9d733cd129f5b89bfb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108695109,
-    "wof:lastmodified":1627522112,
+    "wof:lastmodified":1695886584,
     "wof:name":"Addis Ababa Zone 1",
     "wof:parent_id":85671149,
     "wof:placetype":"county",

--- a/data/110/869/511/1/1108695111.geojson
+++ b/data/110/869/511/1/1108695111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00754,
-    "geom:area_square_m":92084191.133965,
+    "geom:area_square_m":92084191.133956,
     "geom:bbox":"38.655861,8.914416,38.7607,9.035386",
     "geom:latitude":8.983574,
     "geom:longitude":38.706182,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AA.TW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493450,
-    "wof:geomhash":"b2de5d8f7b1d446c59e1d230b15fcb4c",
+    "wof:geomhash":"ad60dabcc4e85f7c84e4c0a61f21dd5b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108695111,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Addis Ababa Zone 2",
     "wof:parent_id":85671149,
     "wof:placetype":"county",

--- a/data/110/869/511/3/1108695113.geojson
+++ b/data/110/869/511/3/1108695113.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019559,
-    "geom:area_square_m":238883642.351408,
+    "geom:area_square_m":238883642.351392,
     "geom:bbox":"38.694668,8.888178,38.910461,9.09797",
     "geom:latitude":8.990719,
     "geom:longitude":38.82195,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AA.TH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493452,
-    "wof:geomhash":"b70e1591dfc3f50cf5bd4009651dbc27",
+    "wof:geomhash":"8f5a20c584d64a54330da7acdad29e63",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108695113,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Addis Ababa Zone 3",
     "wof:parent_id":85671149,
     "wof:placetype":"county",

--- a/data/110/869/511/5/1108695115.geojson
+++ b/data/110/869/511/5/1108695115.geojson
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AA.FO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493453,
-    "wof:geomhash":"f6d02f87eea2d9d6793d8855a3e931fb",
+    "wof:geomhash":"3d99374ea2675b42067f6eb4dd3883e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108695115,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Addis Ababa Zone 4",
     "wof:parent_id":85671149,
     "wof:placetype":"county",

--- a/data/110/869/511/7/1108695117.geojson
+++ b/data/110/869/511/7/1108695117.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003354,
-    "geom:area_square_m":40952459.91795,
+    "geom:area_square_m":40952459.917959,
     "geom:bbox":"38.676174,9.010182,38.773609,9.085994",
     "geom:latitude":9.053851,
     "geom:longitude":38.7226,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AA.FI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493455,
-    "wof:geomhash":"d9d9b51582d47db265281b49fabc106c",
+    "wof:geomhash":"2817dde49767811bf5b03475cc5ef5de",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108695117,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Addis Ababa Zone 5",
     "wof:parent_id":85671149,
     "wof:placetype":"county",

--- a/data/110/869/511/9/1108695119.geojson
+++ b/data/110/869/511/9/1108695119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.009904,
-    "geom:area_square_m":120986978.675939,
+    "geom:area_square_m":120986978.675935,
     "geom:bbox":"38.739723,8.832989,38.875324,8.946543",
     "geom:latitude":8.893538,
     "geom:longitude":38.807061,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AA.SI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493456,
-    "wof:geomhash":"d711246e0bd94dbafc8ed90869237040",
+    "wof:geomhash":"5c0d42efa14490ac35a73101e2245f03",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1108695119,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Addis Ababa Zone 6",
     "wof:parent_id":85671149,
     "wof:placetype":"county",

--- a/data/110/869/512/1/1108695121.geojson
+++ b/data/110/869/512/1/1108695121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.062123,
-    "geom:area_square_m":62313159854.362152,
+    "geom:area_square_m":62313159854.362129,
     "geom:bbox":"40.859951,4.122208,45.005909,6.697906",
     "geom:latitude":5.401541,
     "geom:longitude":42.485494,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"ET.SO.AF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493458,
-    "wof:geomhash":"651e66a5f41c3963fbc6e27cb1a039e7",
+    "wof:geomhash":"d03891daf0c84b67eb677f822e3c580e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695121,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Afder",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/512/5/1108695125.geojson
+++ b/data/110/869/512/5/1108695125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.524462,
-    "geom:area_square_m":6367191730.506999,
+    "geom:area_square_m":6367191730.507138,
     "geom:bbox":"36.283207,10.45452,37.133884,11.475761",
     "geom:latitude":10.938836,
     "geom:longitude":36.69662,
@@ -97,9 +97,10 @@
         "hasc:id":"ET.AM.AA",
         "wd:id":"Q1070718"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493459,
-    "wof:geomhash":"7fff2279b66aaff135a9a7fa283813c8",
+    "wof:geomhash":"f3b5c8ca2109af216f6550765ed8088c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108695125,
-    "wof:lastmodified":1690879613,
+    "wof:lastmodified":1695886706,
     "wof:name":"Agew Awi",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/512/7/1108695127.geojson
+++ b/data/110/869/512/7/1108695127.geojson
@@ -65,6 +65,7 @@
     "wof:concordances":{
         "hasc:id":"ET.SN.KA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493461,
     "wof:geomhash":"e62ffc20cb8f542d298a970e3126be9a",
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695127,
-    "wof:lastmodified":1695886585,
+    "wof:lastmodified":1696023153,
     "wof:name":"Alaba SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/512/7/1108695127.geojson
+++ b/data/110/869/512/7/1108695127.geojson
@@ -77,7 +77,7 @@
         }
     ],
     "wof:id":1108695127,
-    "wof:lastmodified":1694492672,
+    "wof:lastmodified":1695886585,
     "wof:name":"Alaba SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/512/9/1108695129.geojson
+++ b/data/110/869/512/9/1108695129.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695129,
-    "wof:lastmodified":1694492826,
+    "wof:lastmodified":1695886249,
     "wof:name":"Amaro SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/513/1/1108695131.geojson
+++ b/data/110/869/513/1/1108695131.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.945429,
-    "geom:area_square_m":23829144962.363827,
+    "geom:area_square_m":23829144962.363819,
     "geom:bbox":"38.640541,6.864342,40.719498,8.866351",
     "geom:latitude":7.858003,
     "geom:longitude":39.599795,
@@ -115,9 +115,10 @@
         "hasc:id":"ET.OR.AR",
         "wd:id":"Q646859"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493464,
-    "wof:geomhash":"7fc30b3ca7944930ebbcce08189e457c",
+    "wof:geomhash":"5962d2557d941171946513e2ab52dedf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108695131,
-    "wof:lastmodified":1690879610,
+    "wof:lastmodified":1695886704,
     "wof:name":"Arsi",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/513/3/1108695133.geojson
+++ b/data/110/869/513/3/1108695133.geojson
@@ -116,6 +116,7 @@
     "wof:concordances":{
         "hasc:id":"ET.BE.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493465,
     "wof:geomhash":"57775ce8f0f98631068ffb92ee662724",
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":1108695133,
-    "wof:lastmodified":1694492942,
+    "wof:lastmodified":1695886118,
     "wof:name":"Asosa",
     "wof:parent_id":85671147,
     "wof:placetype":"county",

--- a/data/110/869/513/5/1108695135.geojson
+++ b/data/110/869/513/5/1108695135.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000558,
-    "geom:area_square_m":6762023.200182,
+    "geom:area_square_m":6762023.20018,
     "geom:bbox":"37.377319,11.574529,37.405266,11.603682",
     "geom:latitude":11.587917,
     "geom:longitude":37.392702,
@@ -180,9 +180,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AM.BD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493467,
-    "wof:geomhash":"87171947eebe1a266917d1dffc7dd657",
+    "wof:geomhash":"94042e12a200ef583d02a935ed20147d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1108695135,
-    "wof:lastmodified":1566593394,
+    "wof:lastmodified":1695886704,
     "wof:name":"Bahir Dar",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/513/7/1108695137.geojson
+++ b/data/110/869/513/7/1108695137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.973235,
-    "geom:area_square_m":61062089577.413727,
+    "geom:area_square_m":61062089577.414062,
     "geom:bbox":"38.639267,5.357072,42.213078,8.150882",
     "geom:latitude":6.774406,
     "geom:longitude":40.505315,
@@ -122,9 +122,10 @@
     "wof:concordances":{
         "hasc:id":"ET.OR.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493468,
-    "wof:geomhash":"ecaf6ae41ae8f231efe59713672479b2",
+    "wof:geomhash":"a8214f305187712561e34d6bf6bff763",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -134,7 +135,7 @@
         }
     ],
     "wof:id":1108695137,
-    "wof:lastmodified":1566593393,
+    "wof:lastmodified":1695886704,
     "wof:name":"Bale",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/513/9/1108695139.geojson
+++ b/data/110/869/513/9/1108695139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.033177,
-    "geom:area_square_m":407784346.932225,
+    "geom:area_square_m":407784346.93222,
     "geom:bbox":"36.402145,6.146481,36.69402,6.374967",
     "geom:latitude":6.265929,
     "geom:longitude":36.560066,
@@ -73,7 +73,7 @@
     },
     "wof:country":"ET",
     "wof:created":1474493470,
-    "wof:geomhash":"8509f80f3152b8ed6919e15bda3af6e8",
+    "wof:geomhash":"d07a82f6807f0db0682c0249f061530f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -83,7 +83,7 @@
         }
     ],
     "wof:id":1108695139,
-    "wof:lastmodified":1690879610,
+    "wof:lastmodified":1695886704,
     "wof:name":"Basketo SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/514/3/1108695143.geojson
+++ b/data/110/869/514/3/1108695143.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695143,
-    "wof:lastmodified":1694492835,
+    "wof:lastmodified":1695886270,
     "wof:name":"Burji SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/514/5/1108695145.geojson
+++ b/data/110/869/514/5/1108695145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.864537,
-    "geom:area_square_m":10374939955.069725,
+    "geom:area_square_m":10374939955.069305,
     "geom:bbox":"38.434204,13.181948,39.418335,14.640534",
     "geom:latitude":13.944368,
     "geom:longitude":38.926081,
@@ -97,9 +97,10 @@
         "hasc:id":"ET.TI.MH",
         "wd:id":"Q2902680"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493474,
-    "wof:geomhash":"6e2e7c961e19fd3e41dc2382c56c6703",
+    "wof:geomhash":"575fcf408bef2904beaf1a14f133189a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108695145,
-    "wof:lastmodified":1690879610,
+    "wof:lastmodified":1695886704,
     "wof:name":"C. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/514/7/1108695147.geojson
+++ b/data/110/869/514/7/1108695147.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108695147,
-    "wof:lastmodified":1694492841,
+    "wof:lastmodified":1695886284,
     "wof:name":"Dawro",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/514/9/1108695149.geojson
+++ b/data/110/869/514/9/1108695149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.245557,
-    "geom:area_square_m":39720441233.083099,
+    "geom:area_square_m":39720441233.083305,
     "geom:bbox":"42.681351,7.052646,45.624111,9.110385",
     "geom:latitude":8.193024,
     "geom:longitude":44.017094,
@@ -72,9 +72,10 @@
         "hasc:id":"ET.SO.DE",
         "wd:id":"Q3021240"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493477,
-    "wof:geomhash":"ddf0f0bd62a1fc4173a7b79557544457",
+    "wof:geomhash":"4837fa9b48a8e655cab473a88b9459a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108695149,
-    "wof:lastmodified":1690879609,
+    "wof:lastmodified":1695886704,
     "wof:name":"Degehabur",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/515/1/1108695151.geojson
+++ b/data/110/869/515/1/1108695151.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695151,
-    "wof:lastmodified":1694492841,
+    "wof:lastmodified":1695886285,
     "wof:name":"Dirashe SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/515/3/1108695153.geojson
+++ b/data/110/869/515/3/1108695153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.172049,
-    "geom:area_square_m":14249185661.977579,
+    "geom:area_square_m":14249185661.977768,
     "geom:bbox":"37.0462,9.839664,38.533478,11.236545",
     "geom:latitude":10.510956,
     "geom:longitude":37.930298,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AM.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493481,
-    "wof:geomhash":"157779f36a7f60d09ad82f8a6b886bec",
+    "wof:geomhash":"ae9f6150072a69de1c3418cabe6f8830",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695153,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"E. Gojam",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/515/5/1108695155.geojson
+++ b/data/110/869/515/5/1108695155.geojson
@@ -54,6 +54,7 @@
     "wof:concordances":{
         "hasc:id":"ET.OR.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493483,
     "wof:geomhash":"3011cc6f0031e69dd0a19394b8ea0777",
@@ -66,7 +67,7 @@
         }
     ],
     "wof:id":1108695155,
-    "wof:lastmodified":1694492842,
+    "wof:lastmodified":1695886286,
     "wof:name":"E. Harerge",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/515/7/1108695157.geojson
+++ b/data/110/869/515/7/1108695157.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.140878,
-    "geom:area_square_m":13961531069.475685,
+    "geom:area_square_m":13961531069.475918,
     "geom:bbox":"38.066585,6.977734,40.069576,9.177912",
     "geom:latitude":8.217206,
     "geom:longitude":38.98743,
@@ -98,9 +98,10 @@
         "hasc:id":"ET.OR.MS",
         "wd:id":"Q1109846"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493484,
-    "wof:geomhash":"40f921d2382e065f43db82b677e0dbb3",
+    "wof:geomhash":"9a25be1ab1f34ecd12040f84f8f52d44",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108695157,
-    "wof:lastmodified":1690879613,
+    "wof:lastmodified":1695886706,
     "wof:name":"E. Shewa",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/516/1/1108695161.geojson
+++ b/data/110/869/516/1/1108695161.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.485312,
-    "geom:area_square_m":5820191023.220124,
+    "geom:area_square_m":5820191023.220435,
     "geom:bbox":"39.190731,13.554617,39.994682,14.681539",
     "geom:latitude":14.096928,
     "geom:longitude":39.551022,
@@ -90,9 +90,10 @@
         "hasc:id":"ET.TI.MS",
         "wd:id":"Q3316357"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493486,
-    "wof:geomhash":"576ac0a45ae3e80cf05e83e31514bbd3",
+    "wof:geomhash":"ff2d175887b277f981d35b847ca759a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695161,
-    "wof:lastmodified":1690879609,
+    "wof:lastmodified":1695886704,
     "wof:name":"E. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/516/3/1108695163.geojson
+++ b/data/110/869/516/3/1108695163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.825342,
-    "geom:area_square_m":22260208459.718147,
+    "geom:area_square_m":22260208459.718304,
     "geom:bbox":"36.120541,8.514455,37.675812,10.342945",
     "geom:latitude":9.505035,
     "geom:longitude":36.823521,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"ET.OR.MG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493487,
-    "wof:geomhash":"bbfc1a67afb5ade3f4c723f68d5387bc",
+    "wof:geomhash":"01186e0e6b368ca73836f6d4d659a99e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695163,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"E. Wellega",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/516/5/1108695165.geojson
+++ b/data/110/869/516/5/1108695165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.162317,
-    "geom:area_square_m":14240366330.612804,
+    "geom:area_square_m":14240366330.612728,
     "geom:bbox":"41.870323,7.049091,43.152435,8.643288",
     "geom:latitude":7.759186,
     "geom:longitude":42.419414,
@@ -69,9 +69,10 @@
         "hasc:id":"ET.SO.FQ",
         "wd:id":"Q3072754"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493489,
-    "wof:geomhash":"9dec0106d4056c43f98c35c6e474f303",
+    "wof:geomhash":"fb2a66276b91ed398ffd5fb130018ff3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108695165,
-    "wof:lastmodified":1566593392,
+    "wof:lastmodified":1695886704,
     "wof:name":"Fik",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/516/7/1108695167.geojson
+++ b/data/110/869/516/7/1108695167.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108695167,
-    "wof:lastmodified":1694492845,
+    "wof:lastmodified":1695886294,
     "wof:name":"Gamo Gofa",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/516/9/1108695169.geojson
+++ b/data/110/869/516/9/1108695169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.150402,
-    "geom:area_square_m":1844456631.105408,
+    "geom:area_square_m":1844456631.105433,
     "geom:bbox":"34.890678,7.113482,35.367371,7.608082",
     "geom:latitude":7.351474,
     "geom:longitude":35.132719,
@@ -64,7 +64,7 @@
     },
     "wof:country":"ET",
     "wof:created":1474493493,
-    "wof:geomhash":"b46da7c7eb0df5f6adb1679108a675ba",
+    "wof:geomhash":"ff9040aa19520b01d1a3264618920e4a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -74,7 +74,7 @@
         }
     ],
     "wof:id":1108695169,
-    "wof:lastmodified":1690879609,
+    "wof:lastmodified":1695886703,
     "wof:name":"Godere",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/110/869/517/1/1108695171.geojson
+++ b/data/110/869/517/1/1108695171.geojson
@@ -72,7 +72,7 @@
         }
     ],
     "wof:id":1108695171,
-    "wof:lastmodified":1694492672,
+    "wof:lastmodified":1695886585,
     "wof:name":"Guji",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/517/3/1108695173.geojson
+++ b/data/110/869/517/3/1108695173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030501,
-    "geom:area_square_m":372204540.858443,
+    "geom:area_square_m":372204540.858463,
     "geom:bbox":"42.062099,9.189271,42.275394,9.392007",
     "geom:latitude":9.292987,
     "geom:longitude":42.1758,
@@ -65,12 +65,13 @@
     "wof:concordances":{
         "hasc:id":"ET.HA.HA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671163
     ],
     "wof:country":"ET",
     "wof:created":1474493498,
-    "wof:geomhash":"5b730a838fa4fb6a11e6eff9cfd8e4db",
+    "wof:geomhash":"3e39a53d4313242a786f107c6591fc2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +81,7 @@
         }
     ],
     "wof:id":1108695173,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886586,
     "wof:name":"Harar/Hundene",
     "wof:parent_id":85671163,
     "wof:placetype":"county",

--- a/data/110/869/517/5/1108695175.geojson
+++ b/data/110/869/517/5/1108695175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.116486,
-    "geom:area_square_m":1428712537.882348,
+    "geom:area_square_m":1428712537.882319,
     "geom:bbox":"37.351166,7.146977,38.078384,7.500944",
     "geom:latitude":7.296342,
     "geom:longitude":37.758532,
@@ -53,7 +53,7 @@
     "wof:concordances":{},
     "wof:country":"ET",
     "wof:created":1474493502,
-    "wof:geomhash":"d160a73febb31515b9676a6e8014523e",
+    "wof:geomhash":"189a2fb18ceb35c4d9032a8d3af567b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108695175,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886586,
     "wof:name":"Kembata Tembaro",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/517/9/1108695179.geojson
+++ b/data/110/869/517/9/1108695179.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.86062,
-    "geom:area_square_m":10485112189.812506,
+    "geom:area_square_m":10485112189.81212,
     "geom:bbox":"34.83424,8.787545,37.036968,10.607818",
     "geom:latitude":9.834982,
     "geom:longitude":35.802807,
@@ -72,9 +72,10 @@
         "hasc:id":"ET.BE.KM",
         "wd:id":"Q17447305"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493504,
-    "wof:geomhash":"dfdea3813c2c2d249d69a19303c6475d",
+    "wof:geomhash":"f736a133d87b4ef8375cd4acac683d65",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108695179,
-    "wof:lastmodified":1690879607,
+    "wof:lastmodified":1695886703,
     "wof:name":"Kamashi",
     "wof:parent_id":85671147,
     "wof:placetype":"county",

--- a/data/110/869/518/1/1108695181.geojson
+++ b/data/110/869/518/1/1108695181.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108695181,
-    "wof:lastmodified":1694492853,
+    "wof:lastmodified":1695886314,
     "wof:name":"Keffa",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/518/3/1108695183.geojson
+++ b/data/110/869/518/3/1108695183.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695183,
-    "wof:lastmodified":1694492856,
+    "wof:lastmodified":1695886320,
     "wof:name":"Konso SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/518/5/1108695185.geojson
+++ b/data/110/869/518/5/1108695185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.632769,
-    "geom:area_square_m":32334331021.414497,
+    "geom:area_square_m":32334331021.414474,
     "geom:bbox":"43.336971,5.626095,45.946346,7.709302",
     "geom:latitude":6.648438,
     "geom:longitude":44.425002,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"ET.SO.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493509,
-    "wof:geomhash":"83c53775df0ab14c6064fe40171c41b4",
+    "wof:geomhash":"566da3ccaae60b3f4ae12818ca53a170",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695185,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886586,
     "wof:name":"Korahe",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/518/7/1108695187.geojson
+++ b/data/110/869/518/7/1108695187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.950298,
-    "geom:area_square_m":36362257089.272713,
+    "geom:area_square_m":36362257089.27301,
     "geom:bbox":"39.09248,3.402422,42.067848,5.695502",
     "geom:latitude":4.59858,
     "geom:longitude":40.624564,
@@ -75,9 +75,10 @@
         "hasc:id":"ET.SO.LI",
         "wd:id":"Q3237714"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493510,
-    "wof:geomhash":"76d8c49619f5886b438aa59ddbccfc92",
+    "wof:geomhash":"f433ae023f65ca82442082c7d7f5ff3b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108695187,
-    "wof:lastmodified":1690879608,
+    "wof:lastmodified":1695886703,
     "wof:name":"Liben",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/518/9/1108695189.geojson
+++ b/data/110/869/518/9/1108695189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002033,
-    "geom:area_square_m":24437788.387745,
+    "geom:area_square_m":24437788.387747,
     "geom:bbox":"39.444668,13.475578,39.511376,13.53225",
     "geom:latitude":13.50389,
     "geom:longitude":39.477382,
@@ -79,9 +79,10 @@
         "hasc:id":"ET.TI.DB",
         "wd:id":"Q3020955"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493512,
-    "wof:geomhash":"e9d40c8a70fe4de234f403d4c20d93b1",
+    "wof:geomhash":"d90d1c5d41bff014d3134ff9322ba1fd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108695189,
-    "wof:lastmodified":1690879608,
+    "wof:lastmodified":1695886703,
     "wof:name":"Mekele",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/519/1/1108695191.geojson
+++ b/data/110/869/519/1/1108695191.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.188371,
-    "geom:area_square_m":26558949645.360344,
+    "geom:area_square_m":26558949645.360641,
     "geom:bbox":"34.923816,9.942647,36.580696,12.05778",
     "geom:latitude":11.027293,
     "geom:longitude":35.767536,
@@ -90,9 +90,10 @@
         "hasc:id":"ET.BE.MT",
         "wd:id":"Q742955"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493514,
-    "wof:geomhash":"8cf0ed9f13b4c69d951c8060e8f7d25e",
+    "wof:geomhash":"bd5356c5f28f8587ffa79ae471c53831",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -102,7 +103,7 @@
         }
     ],
     "wof:id":1108695191,
-    "wof:lastmodified":1690879607,
+    "wof:lastmodified":1695886703,
     "wof:name":"Metekel",
     "wof:parent_id":85671147,
     "wof:placetype":"county",

--- a/data/110/869/519/3/1108695193.geojson
+++ b/data/110/869/519/3/1108695193.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.783045,
-    "geom:area_square_m":45635890053.218781,
+    "geom:area_square_m":45635890053.21862,
     "geom:bbox":"35.261765,11.416514,38.745594,13.771042",
     "geom:latitude":12.677531,
     "geom:longitude":36.989593,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AM.SG"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493515,
-    "wof:geomhash":"cae922c0ad4cba4b9473c198683d917c",
+    "wof:geomhash":"6c1b49b71319e47010b365e24bc84754",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695193,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886586,
     "wof:name":"N. Gonder",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/519/7/1108695197.geojson
+++ b/data/110/869/519/7/1108695197.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695197,
-    "wof:lastmodified":1694492868,
+    "wof:lastmodified":1695886356,
     "wof:name":"N. Shewa (R3)",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/519/9/1108695199.geojson
+++ b/data/110/869/519/9/1108695199.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695199,
-    "wof:lastmodified":1694492868,
+    "wof:lastmodified":1695886356,
     "wof:name":"N. Shewa (R4)",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/520/1/1108695201.geojson
+++ b/data/110/869/520/1/1108695201.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.054713,
-    "geom:area_square_m":12761409867.11202,
+    "geom:area_square_m":12761409867.111887,
     "geom:bbox":"38.446793,11.346755,40.009651,12.389856",
     "geom:latitude":11.898361,
     "geom:longitude":39.202236,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AM.SW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493519,
-    "wof:geomhash":"5dac5fcf75b1dca3fbace6671662786d",
+    "wof:geomhash":"dd15fff19825d7e23c64c411afbe628f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695201,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886586,
     "wof:name":"N. Wello",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/520/3/1108695203.geojson
+++ b/data/110/869/520/3/1108695203.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.336868,
-    "geom:area_square_m":4091971282.380861,
+    "geom:area_square_m":4091971282.380528,
     "geom:bbox":"39.667816,10.09523,40.199368,11.448734",
     "geom:latitude":10.771548,
     "geom:longitude":40.002363,
@@ -99,9 +99,10 @@
         "hasc:id":"ET.AM.OR",
         "wd:id":"Q600081"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493522,
-    "wof:geomhash":"6dddbb322511239b189451519509981e",
+    "wof:geomhash":"956b7c241411593c8ef1ac8ce986bba4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":1108695203,
-    "wof:lastmodified":1690879608,
+    "wof:lastmodified":1695886704,
     "wof:name":"Oromiya",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/520/5/1108695205.geojson
+++ b/data/110/869/520/5/1108695205.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.212112,
-    "geom:area_square_m":14672743567.253981,
+    "geom:area_square_m":14672743567.253637,
     "geom:bbox":"37.424812,11.038393,38.72142,12.551664",
     "geom:latitude":11.767531,
     "geom:longitude":38.111463,
@@ -94,9 +94,10 @@
         "hasc:id":"ET.AM.DG",
         "wd:id":"Q1070727"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493523,
-    "wof:geomhash":"5d3354d74a2debe6bbfbe09dc1807b27",
+    "wof:geomhash":"3b5da6d257d41072061460583cf33d1a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108695205,
-    "wof:lastmodified":1690879609,
+    "wof:lastmodified":1695886704,
     "wof:name":"S. Gonder",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/520/7/1108695207.geojson
+++ b/data/110/869/520/7/1108695207.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.784195,
-    "geom:area_square_m":9449474457.52125,
+    "geom:area_square_m":9449474457.521843,
     "geom:bbox":"38.994393,12.254976,39.890728,13.64464",
     "geom:latitude":12.961718,
     "geom:longitude":39.474743,
@@ -82,9 +82,10 @@
         "hasc:id":"ET.TI.DB",
         "wd:id":"Q3020955"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493524,
-    "wof:geomhash":"8d211fb8197df64e08c11efb0b88d015",
+    "wof:geomhash":"e45dca6bf7434f17cdd7f9b98dfa0ca7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108695207,
-    "wof:lastmodified":1690879608,
+    "wof:lastmodified":1695886703,
     "wof:name":"S. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/520/9/1108695209.geojson
+++ b/data/110/869/520/9/1108695209.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.424658,
-    "geom:area_square_m":17294794568.021099,
+    "geom:area_square_m":17294794568.021019,
     "geom:bbox":"38.463524,10.158983,40.122463,11.711232",
     "geom:latitude":10.956145,
     "geom:longitude":39.197704,
@@ -101,9 +101,10 @@
         "hasc:id":"ET.AM.DW",
         "wd:id":"Q2919962"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493526,
-    "wof:geomhash":"d3d73d945bbab6f7b1e98c3a373053f5",
+    "wof:geomhash":"1b8f7623b66ef42e1650c2f2fbe3a460",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108695209,
-    "wof:lastmodified":1690879608,
+    "wof:lastmodified":1695886703,
     "wof:name":"S. Wello",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/521/1/1108695211.geojson
+++ b/data/110/869/521/1/1108695211.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695211,
-    "wof:lastmodified":1694492881,
+    "wof:lastmodified":1695886393,
     "wof:name":"S.W. Shewa",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/521/5/1108695215.geojson
+++ b/data/110/869/521/5/1108695215.geojson
@@ -64,7 +64,7 @@
         }
     ],
     "wof:id":1108695215,
-    "wof:lastmodified":1694492883,
+    "wof:lastmodified":1695886397,
     "wof:name":"Selti",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/521/7/1108695217.geojson
+++ b/data/110/869/521/7/1108695217.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108695217,
-    "wof:lastmodified":1694492883,
+    "wof:lastmodified":1695886397,
     "wof:name":"Sheka",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/521/9/1108695219.geojson
+++ b/data/110/869/521/9/1108695219.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.885824,
-    "geom:area_square_m":23215496568.60685,
+    "geom:area_square_m":23215496568.607033,
     "geom:bbox":"35.788189,4.443766,37.067577,6.463396",
     "geom:latitude":5.365544,
     "geom:longitude":36.397319,
@@ -97,9 +97,10 @@
         "hasc:id":"ET.SN.DO",
         "wd:id":"Q3020952"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493534,
-    "wof:geomhash":"0fd3fe4fa2748a5d9d9375c4af55d7c8",
+    "wof:geomhash":"05d3ad51225c8dc8e933002d7f4adac6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108695219,
-    "wof:lastmodified":1690879607,
+    "wof:lastmodified":1695886703,
     "wof:name":"South Omo",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/522/1/1108695221.geojson
+++ b/data/110/869/522/1/1108695221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157602,
-    "geom:area_square_m":1922334532.085363,
+    "geom:area_square_m":1922334532.085409,
     "geom:bbox":"34.100773,9.174226,34.511352,9.751704",
     "geom:latitude":9.448479,
     "geom:longitude":34.273365,
@@ -65,9 +65,10 @@
     "wof:concordances":{
         "hasc:id":"ET.BE.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493535,
-    "wof:geomhash":"222a706ffbf860d259e7dae1fc552125",
+    "wof:geomhash":"9400d7d593868a220c7d357d275731d3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -77,7 +78,7 @@
         }
     ],
     "wof:id":1108695221,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886586,
     "wof:name":"Tongo SW",
     "wof:parent_id":85671147,
     "wof:placetype":"county",

--- a/data/110/869/522/3/1108695223.geojson
+++ b/data/110/869/522/3/1108695223.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.109525,
-    "geom:area_square_m":13463037876.734268,
+    "geom:area_square_m":13463037876.735292,
     "geom:bbox":"36.510883,10.286711,37.857563,11.946078",
     "geom:latitude":11.087305,
     "geom:longitude":37.203192,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"ET.AM.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493536,
-    "wof:geomhash":"10eba5ddbf6c259709a475a1118108c1",
+    "wof:geomhash":"a8926a539fbfa95422871254e9ee2e42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1108695223,
-    "wof:lastmodified":1627522114,
+    "wof:lastmodified":1695886586,
     "wof:name":"W. Gojam",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/522/5/1108695225.geojson
+++ b/data/110/869/522/5/1108695225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.706409,
-    "geom:area_square_m":8519229084.219945,
+    "geom:area_square_m":8519229084.220071,
     "geom:bbox":"38.332706,12.264945,39.324203,13.295953",
     "geom:latitude":12.755616,
     "geom:longitude":38.80806,
@@ -97,9 +97,10 @@
         "hasc:id":"ET.AM.WH",
         "wd:id":"Q1070687"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493538,
-    "wof:geomhash":"37fef68203daecb54f7a5a324e6288d8",
+    "wof:geomhash":"ed832757a167a3faf1c5c8987acaa310",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108695225,
-    "wof:lastmodified":1690879611,
+    "wof:lastmodified":1695886705,
     "wof:name":"W. Hamra",
     "wof:parent_id":85671121,
     "wof:placetype":"county",

--- a/data/110/869/522/7/1108695227.geojson
+++ b/data/110/869/522/7/1108695227.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.434289,
-    "geom:area_square_m":17531581296.135376,
+    "geom:area_square_m":17531581296.135475,
     "geom:bbox":"40.028362,7.881435,41.573277,9.484483",
     "geom:latitude":8.682737,
     "geom:longitude":40.779246,
@@ -76,9 +76,10 @@
         "hasc:id":"ET.OR.MK",
         "wd:id":"Q1109889"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493539,
-    "wof:geomhash":"eae9c637875177692e4542b08d6c4d29",
+    "wof:geomhash":"39d9751032bfcaa7d2af8b0b98f07e5b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108695227,
-    "wof:lastmodified":1690879611,
+    "wof:lastmodified":1695886705,
     "wof:name":"W. Haraerge",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/522/9/1108695229.geojson
+++ b/data/110/869/522/9/1108695229.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.062402,
-    "geom:area_square_m":24745320461.341145,
+    "geom:area_square_m":24745320461.341015,
     "geom:bbox":"36.451977,13.346422,38.678806,14.852769",
     "geom:latitude":13.988508,
     "geom:longitude":37.583398,
@@ -89,9 +89,10 @@
         "hasc:id":"ET.TI.MR",
         "wd:id":"Q2902728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493541,
-    "wof:geomhash":"3db9d3165554c8617d2fdbab0b77d0b3",
+    "wof:geomhash":"f2813f4b7f47e17bad58304c537ab309",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108695229,
-    "wof:lastmodified":1690879611,
+    "wof:lastmodified":1695886704,
     "wof:name":"W. Tigray",
     "wof:parent_id":85671125,
     "wof:placetype":"county",

--- a/data/110/869/523/3/1108695233.geojson
+++ b/data/110/869/523/3/1108695233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.991845,
-    "geom:area_square_m":24318949643.042831,
+    "geom:area_square_m":24318949643.043121,
     "geom:bbox":"34.128887,8.182982,36.137237,10.048877",
     "geom:latitude":9.100979,
     "geom:longitude":35.045378,
@@ -95,9 +95,10 @@
         "hasc:id":"ET.OR.MW",
         "wd:id":"Q1709377"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493543,
-    "wof:geomhash":"27a3bdec04259f097f412042d012b81c",
+    "wof:geomhash":"2fc45fa555bd77c937cce07475886016",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -107,7 +108,7 @@
         }
     ],
     "wof:id":1108695233,
-    "wof:lastmodified":1690879612,
+    "wof:lastmodified":1695886705,
     "wof:name":"W. Wellega",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/523/5/1108695235.geojson
+++ b/data/110/869/523/5/1108695235.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.293459,
-    "geom:area_square_m":52664502964.957764,
+    "geom:area_square_m":52664502964.95771,
     "geom:bbox":"44.52087,5.904538,47.961559,8.446335",
     "geom:latitude":7.268618,
     "geom:longitude":46.054467,
@@ -86,9 +86,10 @@
     "wof:concordances":{
         "hasc:id":"ET.SO.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493544,
-    "wof:geomhash":"97f2bc58bfdf3db55128727ae602726c",
+    "wof:geomhash":"ded83e0fe0c11f642cf9225d6d72a6b3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108695235,
-    "wof:lastmodified":1566593395,
+    "wof:lastmodified":1695886705,
     "wof:name":"Warder",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/110/869/523/7/1108695237.geojson
+++ b/data/110/869/523/7/1108695237.geojson
@@ -63,7 +63,7 @@
         }
     ],
     "wof:id":1108695237,
-    "wof:lastmodified":1694492893,
+    "wof:lastmodified":1695886422,
     "wof:name":"Welayita",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/523/9/1108695239.geojson
+++ b/data/110/869/523/9/1108695239.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.25675,
-    "geom:area_square_m":15341376109.690973,
+    "geom:area_square_m":15341376109.691235,
     "geom:bbox":"37.030472,8.31551,38.712372,9.941409",
     "geom:latitude":9.163848,
     "geom:longitude":37.863402,
@@ -92,9 +92,10 @@
         "hasc:id":"ET.OR.MR",
         "wd:id":"Q1109833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493547,
-    "wof:geomhash":"f2ee080d1bb8c333ceb874e3a6058472",
+    "wof:geomhash":"c1bf73ee10202fb3e189a28ccfe8da79",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108695239,
-    "wof:lastmodified":1690879611,
+    "wof:lastmodified":1695886705,
     "wof:name":"West Shewa",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/110/869/524/1/1108695241.geojson
+++ b/data/110/869/524/1/1108695241.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061794,
-    "geom:area_square_m":756995527.299222,
+    "geom:area_square_m":756995527.29921,
     "geom:bbox":"37.391709,7.568999,37.610836,8.021088",
     "geom:latitude":7.816095,
     "geom:longitude":37.491039,
@@ -70,7 +70,7 @@
     },
     "wof:country":"ET",
     "wof:created":1474493549,
-    "wof:geomhash":"90f4b6facc5e036e78c05ed5e40946a7",
+    "wof:geomhash":"e2e728cd43d2e9c34db62533e6a4d983",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -80,7 +80,7 @@
         }
     ],
     "wof:id":1108695241,
-    "wof:lastmodified":1690879612,
+    "wof:lastmodified":1695886705,
     "wof:name":"Yem SW",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/110/869/524/3/1108695243.geojson
+++ b/data/110/869/524/3/1108695243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.74255,
-    "geom:area_square_m":33179443915.748459,
+    "geom:area_square_m":33179443915.748741,
     "geom:bbox":"39.988212,10.784766,42.358013,13.092632",
     "geom:latitude":11.920802,
     "geom:longitude":41.268557,
@@ -101,9 +101,10 @@
         "hasc:id":"ET.AF.ON",
         "wd:id":"Q3444678"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493553,
-    "wof:geomhash":"2e9ab29ecd2bc628b610e68188d04ca1",
+    "wof:geomhash":"4d474458153b2b98dc856e1376beaa1c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":1108695243,
-    "wof:lastmodified":1690879612,
+    "wof:lastmodified":1695886705,
     "wof:name":"Afar Zone 1",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/524/5/1108695245.geojson
+++ b/data/110/869/524/5/1108695245.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.480809,
-    "geom:area_square_m":29831079558.369259,
+    "geom:area_square_m":29831079558.369942,
     "geom:bbox":"39.663116,12.422873,41.881897,14.50096",
     "geom:latitude":13.468131,
     "geom:longitude":40.591041,
@@ -92,9 +92,10 @@
         "hasc:id":"ET.AF.TW",
         "wd:id":"Q3444683"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493554,
-    "wof:geomhash":"a6768a62e13bff2958a4920b58fe9858",
+    "wof:geomhash":"21623aebaedc221b774aff5401510efd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -104,7 +105,7 @@
         }
     ],
     "wof:id":1108695245,
-    "wof:lastmodified":1690879613,
+    "wof:lastmodified":1695886705,
     "wof:name":"Afar Zone 2",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/524/7/1108695247.geojson
+++ b/data/110/869/524/7/1108695247.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.355947,
-    "geom:area_square_m":16507721056.185617,
+    "geom:area_square_m":16507721056.185385,
     "geom:bbox":"39.793056,8.844014,41.169632,11.20131",
     "geom:latitude":10.063327,
     "geom:longitude":40.540555,
@@ -89,9 +89,10 @@
         "hasc:id":"ET.AF.TH",
         "wd:id":"Q3444674"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493555,
-    "wof:geomhash":"b41ca9ac54868b3fabf5d3fd08b7c6bc",
+    "wof:geomhash":"2dc6c209ca010ef3abb30d137fe12289",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108695247,
-    "wof:lastmodified":1690879612,
+    "wof:lastmodified":1695886705,
     "wof:name":"Afar Zone 3",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/525/1/1108695251.geojson
+++ b/data/110/869/525/1/1108695251.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.916363,
-    "geom:area_square_m":11068688338.07468,
+    "geom:area_square_m":11068688338.074718,
     "geom:bbox":"39.760128,11.662959,40.752163,13.015342",
     "geom:latitude":12.348967,
     "geom:longitude":40.260748,
@@ -89,9 +89,10 @@
         "hasc:id":"ET.AF.FO",
         "wd:id":"Q3444707"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493557,
-    "wof:geomhash":"14f4d5f9912d0e875dfd213a6b8c9cee",
+    "wof:geomhash":"c88b10a8926d4415a269c43de75c86a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -101,7 +102,7 @@
         }
     ],
     "wof:id":1108695251,
-    "wof:lastmodified":1690879610,
+    "wof:lastmodified":1695886705,
     "wof:name":"Afar Zone 4",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/110/869/525/3/1108695253.geojson
+++ b/data/110/869/525/3/1108695253.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.442512,
-    "geom:area_square_m":5379287119.775599,
+    "geom:area_square_m":5379287119.77562,
     "geom:bbox":"39.976719,9.682827,40.651398,11.252142",
     "geom:latitude":10.538401,
     "geom:longitude":40.281384,
@@ -86,9 +86,10 @@
         "hasc:id":"ET.AF.FI",
         "wd:id":"Q3444726"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1474493558,
-    "wof:geomhash":"b45eeaf534825320a9950f2231e23860",
+    "wof:geomhash":"40ef597020f7215b84e0cd49eeb48e1b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -98,7 +99,7 @@
         }
     ],
     "wof:id":1108695253,
-    "wof:lastmodified":1690879611,
+    "wof:lastmodified":1695886705,
     "wof:name":"Afar Zone 5",
     "wof:parent_id":85671129,
     "wof:placetype":"county",

--- a/data/421/171/033/421171033.geojson
+++ b/data/421/171/033/421171033.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.557171,
-    "geom:area_square_m":6820090436.751504,
+    "geom:area_square_m":6820090436.7513,
     "geom:bbox":"32.999939,7.703458,34.161591,8.590205",
     "geom:latitude":8.139511,
     "geom:longitude":33.555656,
@@ -96,12 +96,13 @@
         "wd:id":"Q3575758",
         "wk:page":"Administrative Zone 3 (Gambela)"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459008879,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"924ded4e85b0f0e0c2687074ed8a4068",
+    "wof:geomhash":"ec6f2d4e5da2f057ecc8b872d77a39e8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -111,7 +112,7 @@
         }
     ],
     "wof:id":421171033,
-    "wof:lastmodified":1582362126,
+    "wof:lastmodified":1695886035,
     "wof:name":"Gambella Zone 3",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/421/182/273/421182273.geojson
+++ b/data/421/182/273/421182273.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.509494,
-    "geom:area_square_m":6236402637.676391,
+    "geom:area_square_m":6236402637.676414,
     "geom:bbox":"37.466553,7.759041,38.720455,8.46159",
     "geom:latitude":8.146077,
     "geom:longitude":38.082019,
@@ -117,12 +117,13 @@
         "qs_pg:id":897510,
         "wd:id":"Q1070678"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459009324,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"da9ec6d27486568e15776d78a53fbe17",
+    "wof:geomhash":"9e93e6b9816c29d5c259ae0d1f2ca0e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":421182273,
-    "wof:lastmodified":1690879624,
+    "wof:lastmodified":1695886035,
     "wof:name":"Gurage",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/421/184/699/421184699.geojson
+++ b/data/421/184/699/421184699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.528691,
-    "geom:area_square_m":30767653542.261337,
+    "geom:area_square_m":30767653542.261135,
     "geom:bbox":"40.6954,9.308142,42.946651,11.08447",
     "geom:latitude":10.252547,
     "geom:longitude":41.8403,
@@ -127,12 +127,13 @@
         "wd:id":"Q2279103",
         "wk:page":"Shinile Zone"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459009419,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bdc01eadcaf7db660cf3d012afee8437",
+    "wof:geomhash":"9f6ef14df6a2a8b85ea15f4f1fa7e2b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":421184699,
-    "wof:lastmodified":1690879623,
+    "wof:lastmodified":1695886035,
     "wof:name":"Shinile",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/188/217/421188217.geojson
+++ b/data/421/188/217/421188217.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.352218,
-    "geom:area_square_m":4310446382.010016,
+    "geom:area_square_m":4310446382.010176,
     "geom:bbox":"34.001209,7.84153,35.093441,8.612321",
     "geom:latitude":8.223344,
     "geom:longitude":34.449764,
@@ -90,12 +90,13 @@
         "hasc:id":"ET.GA.ON",
         "qs_pg:id":1090862
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459009538,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"810d4053f853883de6a37fdef356e1c0",
+    "wof:geomhash":"6d0fb84c70eea1866c987126fc61ba96",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421188217,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886584,
     "wof:name":"Gambela Zone 1",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/421/188/225/421188225.geojson
+++ b/data/421/188/225/421188225.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.306927,
-    "geom:area_square_m":53074824640.544243,
+    "geom:area_square_m":53074824640.544289,
     "geom:bbox":"36.716114,3.513587,39.748768,6.599661",
     "geom:latitude":4.683609,
     "geom:longitude":38.28047,
@@ -124,12 +124,13 @@
         "qs_pg:id":1090865,
         "wd:id":"Q1109855"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459009538,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"63f5cdf51995ea1ac8ea9fc9be320327",
+    "wof:geomhash":"eccc09bcb08f39851a73be33d3bba6a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":421188225,
-    "wof:lastmodified":1690879620,
+    "wof:lastmodified":1695886035,
     "wof:name":"Borena",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/421/188/343/421188343.geojson
+++ b/data/421/188/343/421188343.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.096211,
-    "geom:area_square_m":13374745675.995712,
+    "geom:area_square_m":13374745675.995735,
     "geom:bbox":"42.437595,8.632634,43.978771,10.189709",
     "geom:latitude":9.344902,
     "geom:longitude":43.074909,
@@ -97,12 +97,13 @@
         "qs_pg:id":19680,
         "wd:id":"Q3178653"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459009542,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21958ad5a580097e9fe88fae014597d3",
+    "wof:geomhash":"9b346873e9c492a5a29471894ebdff3c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":421188343,
-    "wof:lastmodified":1690879620,
+    "wof:lastmodified":1695886035,
     "wof:name":"Jijiga",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/190/257/421190257.geojson
+++ b/data/421/190/257/421190257.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086721,
-    "geom:area_square_m":1057265695.580524,
+    "geom:area_square_m":1057265695.580476,
     "geom:bbox":"41.731247,9.47579,42.343376,9.787045",
     "geom:latitude":9.609687,
     "geom:longitude":42.006561,
@@ -314,6 +314,7 @@
         "wd:id":"Q193486",
         "wk:page":"Dire Dawa"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:coterminous":[
         85671159
     ],
@@ -322,7 +323,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55af5b00c86b1ce9f1ad264d852e5e71",
+    "wof:geomhash":"d1cca387757d0bd6c9bf4ec69a4e4857",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -332,7 +333,7 @@
         }
     ],
     "wof:id":421190257,
-    "wof:lastmodified":1690879621,
+    "wof:lastmodified":1695886411,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85671159,
     "wof:placetype":"county",

--- a/data/421/200/119/421200119.geojson
+++ b/data/421/200/119/421200119.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.710452,
-    "geom:area_square_m":33320000437.867363,
+    "geom:area_square_m":33320000437.86718,
     "geom:bbox":"42.002403,4.936429,45.671398,7.33065",
     "geom:latitude":6.168042,
     "geom:longitude":43.581612,
@@ -225,12 +225,13 @@
         "qs_pg:id":784356,
         "wd:id":"Q744673"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459010012,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1f20d3b773afce26074c735dda06e7f5",
+    "wof:geomhash":"639bd5d55dcdfdf1bc59d4e49507e6dc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -240,7 +241,7 @@
         }
     ],
     "wof:id":421200119,
-    "wof:lastmodified":1690879623,
+    "wof:lastmodified":1695886118,
     "wof:name":"Gode",
     "wof:parent_id":85671155,
     "wof:placetype":"county",

--- a/data/421/200/427/421200427.geojson
+++ b/data/421/200/427/421200427.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.029489,
-    "geom:area_square_m":12618373377.033325,
+    "geom:area_square_m":12618373377.033077,
     "geom:bbox":"33.523232,7.008826,35.019665,8.068907",
     "geom:latitude":7.582963,
     "geom:longitude":34.37059,
@@ -90,12 +90,13 @@
         "hasc:id":"ET.GA.TW",
         "qs_pg:id":1249080
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459010022,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7d2d83800ca394209dea8a46d4718b95",
+    "wof:geomhash":"59bc858fc7921ffa239e66428e7ad8e5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":421200427,
-    "wof:lastmodified":1627522113,
+    "wof:lastmodified":1695886585,
     "wof:name":"Gambela Zone 2",
     "wof:parent_id":85671137,
     "wof:placetype":"county",

--- a/data/421/204/107/421204107.geojson
+++ b/data/421/204/107/421204107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110856,
-    "geom:area_square_m":1362867124.586391,
+    "geom:area_square_m":1362867124.58647,
     "geom:bbox":"38.083859,5.843603,38.442562,6.425851",
     "geom:latitude":6.147834,
     "geom:longitude":38.276621,
@@ -125,12 +125,13 @@
         "qs_pg:id":238118,
         "wd:id":"Q500213"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459010174,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"57e1e19b2497c24b482ef7fa5d5cfbfc",
+    "wof:geomhash":"98c46a27d707e3e3e460429c79bf47c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -140,7 +141,7 @@
         }
     ],
     "wof:id":421204107,
-    "wof:lastmodified":1690879616,
+    "wof:lastmodified":1695886035,
     "wof:name":"Gedeo",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/421/204/421/421204421.geojson
+++ b/data/421/204/421/421204421.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.554807,
-    "geom:area_square_m":6813824575.036407,
+    "geom:area_square_m":6813824575.036502,
     "geom:bbox":"38.00267,6.142382,39.135849,7.168602",
     "geom:latitude":6.66897,
     "geom:longitude":38.547864,
@@ -163,12 +163,13 @@
         "qs_pg:id":1307293,
         "wd:id":"Q1070673"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1459010185,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"d659ce468761f5fcd649528848d36e28",
+    "wof:geomhash":"e7ea8eb922f276bf284d5e1b76781510",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":421204421,
-    "wof:lastmodified":1690879616,
+    "wof:lastmodified":1695886035,
     "wof:name":"Sidama",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/856/322/57/85632257.geojson
+++ b/data/856/322/57/85632257.geojson
@@ -1245,6 +1245,7 @@
         "hasc:id":"ET",
         "icao:code":"ET",
         "ioc:id":"ETH",
+        "iso:code":"ET",
         "itu:id":"ETH",
         "loc:id":"n79081279",
         "m49:code":"231",
@@ -1259,6 +1260,7 @@
         "wk:page":"Ethiopia",
         "wmo:id":"ET"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:country_alpha3":"ETH",
     "wof:geom_alt":[
@@ -1280,7 +1282,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1694639559,
+    "wof:lastmodified":1695881217,
     "wof:name":"Ethiopia",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/711/21/85671121.geojson
+++ b/data/856/711/21/85671121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":12.65032,
-    "geom:area_square_m":153216771228.035278,
+    "geom:area_square_m":153216771228.033173,
     "geom:bbox":"35.261765,8.735217,40.199368,13.771042",
     "geom:latitude":11.573169,
     "geom:longitude":38.068189,
@@ -340,17 +340,19 @@
         "gn:id":444180,
         "gp:id":56013541,
         "hasc:id":"ET.AM",
+        "iso:code":"ET-AM",
         "iso:id":"ET-AM",
         "qs_pg:id":1086828,
         "unlc:id":"ET-AM",
         "wd:id":"Q203009",
         "wk:page":"Amhara Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cfb73d2a1adfd94dfd43d5e472301995",
+    "wof:geomhash":"f65d2f7c5cb7e57791ea6275565df0c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879602,
+    "wof:lastmodified":1695884374,
     "wof:name":"Amhara",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/25/85671125.geojson
+++ b/data/856/711/25/85671125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.198478,
-    "geom:area_square_m":50414363685.539749,
+    "geom:area_square_m":50414363685.539398,
     "geom:bbox":"36.451977,12.254976,39.994682,14.852769",
     "geom:latitude":13.799932,
     "geom:longitude":38.441505,
@@ -346,17 +346,19 @@
         "gn:id":444187,
         "gp:id":2345312,
         "hasc:id":"ET.TI",
+        "iso:code":"ET-TI",
         "iso:id":"ET-TI",
         "qs_pg:id":890064,
         "unlc:id":"ET-TI",
         "wd:id":"Q200127",
         "wk:page":"Tigray Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7c87bfe9a71a775ea44ff9f79e7eb56d",
+    "wof:geomhash":"994617054c0d551b35111bc749428d31",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -371,7 +373,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879604,
+    "wof:lastmodified":1695884375,
     "wof:name":"Tigray",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/29/85671129.geojson
+++ b/data/856/711/29/85671129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":7.938181,
-    "geom:area_square_m":95966219988.155182,
+    "geom:area_square_m":95966219988.155655,
     "geom:bbox":"39.663116,8.844014,42.358013,14.50096",
     "geom:latitude":12.05945,
     "geom:longitude":40.761101,
@@ -326,17 +326,19 @@
         "gn:id":444179,
         "gp:id":56013537,
         "hasc:id":"ET.AF",
+        "iso:code":"ET-AF",
         "iso:id":"ET-AF",
         "qs_pg:id":223945,
         "unlc:id":"ET-AF",
         "wd:id":"Q193494",
         "wk:page":"Afar Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"9550aca8a970b74d6d2f307dae2781c7",
+    "wof:geomhash":"b72bf1ba27c35e9e2638816074e7ed19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -351,7 +353,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879602,
+    "wof:lastmodified":1695884375,
     "wof:name":"Afar",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/33/85671133.geojson
+++ b/data/856/711/33/85671133.geojson
@@ -8,7 +8,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.224607,
-    "geom:area_square_m":113323793116.269028,
+    "geom:area_square_m":113323793116.269272,
     "geom:bbox":"34.189015,4.443766,39.135849,8.46159",
     "geom:latitude":6.470633,
     "geom:longitude":36.750435,
@@ -345,15 +345,17 @@
         "gn:id":444188,
         "gp:id":56013536,
         "hasc:id":"ET.SN",
+        "iso:code":"ET-SN",
         "iso:id":"ET-SN",
         "qs_pg:id":4715,
         "wd:id":"Q203193"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"40801fb4cd322c5d76a1f155d4455968",
+    "wof:geomhash":"58a9258666b8cb40985c36a12a70ddae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -368,7 +370,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879601,
+    "wof:lastmodified":1695884375,
     "wof:name":"Southern Nations, Nationalities and Peoples",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/37/85671137.geojson
+++ b/data/856/711/37/85671137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.08928,
-    "geom:area_square_m":25593366826.900021,
+    "geom:area_square_m":25593366826.899891,
     "geom:bbox":"32.999939,7.008826,35.367371,8.612321",
     "geom:latitude":7.822677,
     "geom:longitude":34.221474,
@@ -315,16 +315,18 @@
         "gn:id":444183,
         "gp:id":56013539,
         "hasc:id":"ET.GA",
+        "iso:code":"ET-GA",
         "iso:id":"ET-GA",
         "qs_pg:id":1095742,
         "wd:id":"Q207638",
         "wk:page":"Gambela Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"fa2f104029f0b77db86a95a6ab2097c7",
+    "wof:geomhash":"bee27febe2c691547aa378a9ffdf4a70",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879602,
+    "wof:lastmodified":1695884375,
     "wof:name":"Gambella Peoples",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/41/85671141.geojson
+++ b/data/856/711/41/85671141.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":26.583367,
-    "geom:area_square_m":325741999860.511047,
+    "geom:area_square_m":325741999860.510986,
     "geom:bbox":"34.128887,3.513587,42.915611,10.389673",
     "geom:latitude":7.514718,
     "geom:longitude":38.716034,
@@ -335,16 +335,18 @@
         "gn:id":444185,
         "gp:id":56013545,
         "hasc:id":"ET.OR",
+        "iso:code":"ET-OR",
         "iso:id":"ET-OR",
         "qs_pg:id":1136824,
         "unlc:id":"ET-OR",
         "wd:id":"Q202107"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"38e94cdf74a49e9c03e74a98ac24c52e",
+    "wof:geomhash":"ff82e53ca34b95363bb5ff0a83e214ca",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -359,7 +361,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879603,
+    "wof:lastmodified":1695884375,
     "wof:name":"Oromiya",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/47/85671147.geojson
+++ b/data/856/711/47/85671147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.117991,
-    "geom:area_square_m":50053260170.879852,
+    "geom:area_square_m":50053260170.880905,
     "geom:bbox":"34.100773,8.787545,37.036968,12.05778",
     "geom:latitude":10.562211,
     "geom:longitude":35.479268,
@@ -325,15 +325,17 @@
         "gn:id":444181,
         "gp:id":56013538,
         "hasc:id":"ET.BE",
+        "iso:code":"ET-BE",
         "iso:id":"ET-BE",
         "qs_pg:id":481505,
         "wd:id":"Q207635"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"32083aba8d125554e1460fe8b9238d49",
+    "wof:geomhash":"8df1b4060deedcaf1a29fe39afa06c81",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -348,7 +350,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879604,
+    "wof:lastmodified":1695884375,
     "wof:name":"Beneshangul Gumuz",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/49/85671149.geojson
+++ b/data/856/711/49/85671149.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.045285,
-    "geom:area_square_m":553095457.00583,
+    "geom:area_square_m":553095457.005975,
     "geom:bbox":"38.655861,8.832989,38.910461,9.099371",
     "geom:latitude":8.979066,
     "geom:longitude":38.786796,
@@ -674,11 +674,13 @@
         "gn:id":444178,
         "gp:id":56013543,
         "hasc:id":"ET.AA",
+        "iso:code":"ET-AA",
         "iso:id":"ET-AA",
         "qs_pg:id":481499,
         "unlc:id":"ET-AA",
         "wd:id":"Q3624"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421170391
     ],
@@ -686,7 +688,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a56d100115d2c8887438662331ed250b",
+    "wof:geomhash":"81e1621a3570481ef904fbc8d4c35267",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -701,7 +703,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879604,
+    "wof:lastmodified":1695884375,
     "wof:name":"Addis Ababa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/55/85671155.geojson
+++ b/data/856/711/55/85671155.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":25.681878,
-    "geom:area_square_m":315097458149.829407,
+    "geom:area_square_m":315097458149.828247,
     "geom:bbox":"39.09248,3.402422,47.961559,11.08447",
     "geom:latitude":6.935592,
     "geom:longitude":43.335078,
@@ -323,17 +323,19 @@
         "gn:id":444186,
         "gp:id":56013540,
         "hasc:id":"ET.SO",
+        "iso:code":"ET-SO",
         "iso:id":"ET-SO",
         "qs_pg:id":896705,
         "unlc:id":"ET-SO",
         "wd:id":"Q202800",
         "wk:page":"Somali Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ET",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3329cae3a46b184f3ae9d4e1908e8865",
+    "wof:geomhash":"c419390466ed9ba653289992a9e44fdc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -348,7 +350,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879603,
+    "wof:lastmodified":1695884375,
     "wof:name":"Somali",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/59/85671159.geojson
+++ b/data/856/711/59/85671159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086721,
-    "geom:area_square_m":1057265695.580524,
+    "geom:area_square_m":1057265695.580476,
     "geom:bbox":"41.731247,9.47579,42.343376,9.787045",
     "geom:latitude":9.609687,
     "geom:longitude":42.006561,
@@ -357,11 +357,13 @@
         "gn:id":444182,
         "gp:id":56013542,
         "hasc:id":"ET.DD",
+        "iso:code":"ET-DD",
         "iso:id":"ET-DD",
         "qs_pg:id":1105137,
         "unlc:id":"ET-DD",
         "wd:id":"Q193486"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         421190257
     ],
@@ -369,7 +371,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"55af5b00c86b1ce9f1ad264d852e5e71",
+    "wof:geomhash":"d1cca387757d0bd6c9bf4ec69a4e4857",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879601,
+    "wof:lastmodified":1695884477,
     "wof:name":"Dire Dawa",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/856/711/63/85671163.geojson
+++ b/data/856/711/63/85671163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030501,
-    "geom:area_square_m":372204540.858443,
+    "geom:area_square_m":372204540.858463,
     "geom:bbox":"42.062099,9.189271,42.275394,9.392007",
     "geom:latitude":9.292987,
     "geom:longitude":42.1758,
@@ -330,11 +330,13 @@
         "gn:id":444184,
         "gp:id":56013544,
         "hasc:id":"ET.HA",
+        "iso:code":"ET-HA",
         "iso:id":"ET-HA",
         "qs_pg:id":1086829,
         "wd:id":"Q1033855",
         "wk:page":"Harari Region"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         1108695173
     ],
@@ -342,7 +344,7 @@
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5b730a838fa4fb6a11e6eff9cfd8e4db",
+    "wof:geomhash":"3e39a53d4313242a786f107c6591fc2e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "amh"
     ],
-    "wof:lastmodified":1690879603,
+    "wof:lastmodified":1695884477,
     "wof:name":"Harari People",
     "wof:parent_id":85632257,
     "wof:placetype":"region",

--- a/data/890/418/071/890418071.geojson
+++ b/data/890/418/071/890418071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.514824,
-    "geom:area_square_m":18552252073.328823,
+    "geom:area_square_m":18552252073.328934,
     "geom:bbox":"35.852131,7.224869,37.627087,8.87549",
     "geom:latitude":7.915881,
     "geom:longitude":36.826156,
@@ -118,12 +118,13 @@
         "wd:id":"Q1109877",
         "wk:page":"Jimma Zone"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1469051233,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"e1ce58df59d5aeefaae9260aa122db3c",
+    "wof:geomhash":"f970152cc00658c041751e06055cd14c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":890418071,
-    "wof:lastmodified":1690879635,
+    "wof:lastmodified":1695886035,
     "wof:name":"Jimma",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/890/421/359/890421359.geojson
+++ b/data/890/421/359/890421359.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.329937,
-    "geom:area_square_m":4044525188.481282,
+    "geom:area_square_m":4044525188.48126,
     "geom:bbox":"37.334598,7.06671,38.135704,7.920495",
     "geom:latitude":7.530608,
     "geom:longitude":37.776639,
@@ -113,12 +113,13 @@
         "wd:id":"Q3125547",
         "wk:page":"Hadiya Zone"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1469051389,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a6b968088e906b3e6ce43fcc758e6791",
+    "wof:geomhash":"0af90e7dea9d4f298d0896452e18f28b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -128,7 +129,7 @@
         }
     ],
     "wof:id":890421359,
-    "wof:lastmodified":1690879634,
+    "wof:lastmodified":1695886035,
     "wof:name":"Hadiya",
     "wof:parent_id":85671133,
     "wof:placetype":"county",

--- a/data/890/446/963/890446963.geojson
+++ b/data/890/446/963/890446963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.343627,
-    "geom:area_square_m":16440324796.923014,
+    "geom:area_square_m":16440324796.922632,
     "geom:bbox":"34.870197,7.460334,36.822906,8.961849",
     "geom:latitude":8.291854,
     "geom:longitude":35.73734,
@@ -111,12 +111,13 @@
         "wd:id":"Q768586",
         "wk:page":"Illubabor Zone"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1469052574,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"21f1fb5150e7022e1b0d6e70d12d6c67",
+    "wof:geomhash":"11a0a52b55b62edce8c1cb1ee98cd0ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":890446963,
-    "wof:lastmodified":1690879626,
+    "wof:lastmodified":1695886035,
     "wof:name":"Illubabor",
     "wof:parent_id":85671141,
     "wof:placetype":"county",

--- a/data/890/450/041/890450041.geojson
+++ b/data/890/450/041/890450041.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.891712,
-    "geom:area_square_m":23245286625.331654,
+    "geom:area_square_m":23245286625.332375,
     "geom:bbox":"34.189015,5.334055,36.137562,7.212884",
     "geom:latitude":6.388331,
     "geom:longitude":35.408656,
@@ -111,12 +111,13 @@
         "wd:id":"Q2895686",
         "wk:page":"Bench Maji Zone"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"ET",
     "wof:created":1469052721,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"5743d182c4c23bbe5d411d110237db02",
+    "wof:geomhash":"fc51c8234f5e6eea20da722d80dfbb16",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -126,7 +127,7 @@
         }
     ],
     "wof:id":890450041,
-    "wof:lastmodified":1690879636,
+    "wof:lastmodified":1695886036,
     "wof:name":"Bench Maji",
     "wof:parent_id":85671133,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.